### PR TITLE
feat: update references of bucharest-gold to use the nodeshift namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 # Only the node version 8 job will upload the lockfile
 after_script: greenkeeper-lockfile-upload
 notifications:
-  irc: "irc.freenode.org#bucharest-gold"
+  irc: "irc.freenode.org#nodeshift"
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,196 +3,196 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 <a name="1.12.0"></a>
-# [1.12.0](https://github.com/bucharest-gold/nodeshift/compare/v1.11.0...v1.12.0) (2018-08-15)
+# [1.12.0](https://github.com/nodeshift/nodeshift/compare/v1.11.0...v1.12.0) (2018-08-15)
 
 
 ### Features
 
-* add the imageTag flag. ([#258](https://github.com/bucharest-gold/nodeshift/issues/258)) ([399081e](https://github.com/bucharest-gold/nodeshift/commit/399081e)), closes [#256](https://github.com/bucharest-gold/nodeshift/issues/256)
+* add the imageTag flag. ([#258](https://github.com/nodeshift/nodeshift/issues/258)) ([399081e](https://github.com/nodeshift/nodeshift/commit/399081e)), closes [#256](https://github.com/nodeshift/nodeshift/issues/256)
 
 
 
 <a name="1.11.0"></a>
-# [1.11.0](https://github.com/bucharest-gold/nodeshift/compare/v1.10.0...v1.11.0) (2018-07-24)
+# [1.11.0](https://github.com/nodeshift/nodeshift/compare/v1.10.0...v1.11.0) (2018-07-24)
 
 
 ### Features
 
-* create/update/remove a config map if there is one in the .nodeshift directory. ([#255](https://github.com/bucharest-gold/nodeshift/issues/255)) ([f6f96c7](https://github.com/bucharest-gold/nodeshift/commit/f6f96c7)), closes [#203](https://github.com/bucharest-gold/nodeshift/issues/203)
+* create/update/remove a config map if there is one in the .nodeshift directory. ([#255](https://github.com/nodeshift/nodeshift/issues/255)) ([f6f96c7](https://github.com/nodeshift/nodeshift/commit/f6f96c7)), closes [#203](https://github.com/nodeshift/nodeshift/issues/203)
 
 
 
 <a name="1.10.0"></a>
-# [1.10.0](https://github.com/bucharest-gold/nodeshift/compare/v1.9.1...v1.10.0) (2018-07-19)
+# [1.10.0](https://github.com/nodeshift/nodeshift/compare/v1.9.1...v1.10.0) (2018-07-19)
 
 
 ### Features
 
-* add a flag, --build.incremental, that turns on incremental builds. ([#254](https://github.com/bucharest-gold/nodeshift/issues/254)) ([68be3dc](https://github.com/bucharest-gold/nodeshift/commit/68be3dc)), closes [#253](https://github.com/bucharest-gold/nodeshift/issues/253)
+* add a flag, --build.incremental, that turns on incremental builds. ([#254](https://github.com/nodeshift/nodeshift/issues/254)) ([68be3dc](https://github.com/nodeshift/nodeshift/commit/68be3dc)), closes [#253](https://github.com/nodeshift/nodeshift/issues/253)
 
 
 
 <a name="1.9.1"></a>
-## [1.9.1](https://github.com/bucharest-gold/nodeshift/compare/v1.9.0...v1.9.1) (2018-07-03)
+## [1.9.1](https://github.com/nodeshift/nodeshift/compare/v1.9.0...v1.9.1) (2018-07-03)
 
 
 ### Bug Fixes
 
-* **health-check enricher:** don't fail if there is no dependencies prop in the package.json ([#250](https://github.com/bucharest-gold/nodeshift/issues/250)) ([96789c1](https://github.com/bucharest-gold/nodeshift/commit/96789c1)), closes [#249](https://github.com/bucharest-gold/nodeshift/issues/249)
+* **health-check enricher:** don't fail if there is no dependencies prop in the package.json ([#250](https://github.com/nodeshift/nodeshift/issues/250)) ([96789c1](https://github.com/nodeshift/nodeshift/commit/96789c1)), closes [#249](https://github.com/nodeshift/nodeshift/issues/249)
 
 
 
 <a name="1.9.0"></a>
-# [1.9.0](https://github.com/bucharest-gold/nodeshift/compare/v1.8.1...v1.9.0) (2018-06-07)
+# [1.9.0](https://github.com/nodeshift/nodeshift/compare/v1.8.1...v1.9.0) (2018-06-07)
 
 
 ### Bug Fixes
 
-* travis-ci should use npm install instead of npm ci ([#242](https://github.com/bucharest-gold/nodeshift/issues/242)) ([938ec7d](https://github.com/bucharest-gold/nodeshift/commit/938ec7d))
+* travis-ci should use npm install instead of npm ci ([#242](https://github.com/nodeshift/nodeshift/issues/242)) ([938ec7d](https://github.com/nodeshift/nodeshift/commit/938ec7d))
 
 
 ### Features
 
-* add the namespace flag ([#234](https://github.com/bucharest-gold/nodeshift/issues/234)) ([13e5316](https://github.com/bucharest-gold/nodeshift/commit/13e5316)), closes [#233](https://github.com/bucharest-gold/nodeshift/issues/233)
-* **ingress:** create an Ingress if there is one in the .nodeshift directory ([#244](https://github.com/bucharest-gold/nodeshift/issues/244)) ([f98cad4](https://github.com/bucharest-gold/nodeshift/commit/f98cad4)), closes [#238](https://github.com/bucharest-gold/nodeshift/issues/238)
+* add the namespace flag ([#234](https://github.com/nodeshift/nodeshift/issues/234)) ([13e5316](https://github.com/nodeshift/nodeshift/commit/13e5316)), closes [#233](https://github.com/nodeshift/nodeshift/issues/233)
+* **ingress:** create an Ingress if there is one in the .nodeshift directory ([#244](https://github.com/nodeshift/nodeshift/issues/244)) ([f98cad4](https://github.com/nodeshift/nodeshift/commit/f98cad4)), closes [#238](https://github.com/nodeshift/nodeshift/issues/238)
 
 
 
 <a name="1.8.1"></a>
-## [1.8.1](https://github.com/bucharest-gold/nodeshift/compare/v1.8.0...v1.8.1) (2018-05-25)
+## [1.8.1](https://github.com/nodeshift/nodeshift/compare/v1.8.0...v1.8.1) (2018-05-25)
 
 
 ### Bug Fixes
 
-* **README:** remove the section talking about default environment variables being added to the DeploymentConfig ([14cfb74](https://github.com/bucharest-gold/nodeshift/commit/14cfb74)), closes [#231](https://github.com/bucharest-gold/nodeshift/issues/231)
+* **README:** remove the section talking about default environment variables being added to the DeploymentConfig ([14cfb74](https://github.com/nodeshift/nodeshift/commit/14cfb74)), closes [#231](https://github.com/nodeshift/nodeshift/issues/231)
 
 
 
 <a name="1.8.0"></a>
-# [1.8.0](https://github.com/bucharest-gold/nodeshift/compare/v1.7.3...v1.8.0) (2018-05-25)
+# [1.8.0](https://github.com/nodeshift/nodeshift/compare/v1.7.3...v1.8.0) (2018-05-25)
 
 
 ### Features
 
-* add the --deploy.env flag ([#226](https://github.com/bucharest-gold/nodeshift/issues/226)) ([74c482c](https://github.com/bucharest-gold/nodeshift/commit/74c482c)), closes [#223](https://github.com/bucharest-gold/nodeshift/issues/223)
+* add the --deploy.env flag ([#226](https://github.com/nodeshift/nodeshift/issues/226)) ([74c482c](https://github.com/nodeshift/nodeshift/commit/74c482c)), closes [#223](https://github.com/nodeshift/nodeshift/issues/223)
 
 
 
 <a name="1.7.3"></a>
-## [1.7.3](https://github.com/bucharest-gold/nodeshift/compare/v1.7.2...v1.7.3) (2018-05-21)
+## [1.7.3](https://github.com/nodeshift/nodeshift/compare/v1.7.2...v1.7.3) (2018-05-21)
 
 
 ### Bug Fixes
 
-* **package:** update request to version 2.87.0 ([#224](https://github.com/bucharest-gold/nodeshift/issues/224)) ([2af9b47](https://github.com/bucharest-gold/nodeshift/commit/2af9b47))
+* **package:** update request to version 2.87.0 ([#224](https://github.com/nodeshift/nodeshift/issues/224)) ([2af9b47](https://github.com/nodeshift/nodeshift/commit/2af9b47))
 
 
 
 <a name="1.7.2"></a>
-## [1.7.2](https://github.com/bucharest-gold/nodeshift/compare/v1.7.1...v1.7.2) (2018-05-14)
+## [1.7.2](https://github.com/nodeshift/nodeshift/compare/v1.7.1...v1.7.2) (2018-05-14)
 
 
 ### Bug Fixes
 
-* add a name (http) to the service port ([#218](https://github.com/bucharest-gold/nodeshift/issues/218)) ([c599dc0](https://github.com/bucharest-gold/nodeshift/commit/c599dc0))
-* remove the hardcoded 8080 for ports. ([bd3f10b](https://github.com/bucharest-gold/nodeshift/commit/bd3f10b)), closes [#216](https://github.com/bucharest-gold/nodeshift/issues/216)
-* update openshift-rest-client and request for security vulnerability.  https://nodesecurity.io/advisories/606 ([#220](https://github.com/bucharest-gold/nodeshift/issues/220)) ([95cf4c9](https://github.com/bucharest-gold/nodeshift/commit/95cf4c9))
+* add a name (http) to the service port ([#218](https://github.com/nodeshift/nodeshift/issues/218)) ([c599dc0](https://github.com/nodeshift/nodeshift/commit/c599dc0))
+* remove the hardcoded 8080 for ports. ([bd3f10b](https://github.com/nodeshift/nodeshift/commit/bd3f10b)), closes [#216](https://github.com/nodeshift/nodeshift/issues/216)
+* update openshift-rest-client and request for security vulnerability.  https://nodesecurity.io/advisories/606 ([#220](https://github.com/nodeshift/nodeshift/issues/220)) ([95cf4c9](https://github.com/nodeshift/nodeshift/commit/95cf4c9))
 
 
 
 <a name="1.7.1"></a>
-## [1.7.1](https://github.com/bucharest-gold/nodeshift/compare/v1.7.0...v1.7.1) (2018-04-10)
+## [1.7.1](https://github.com/nodeshift/nodeshift/compare/v1.7.0...v1.7.1) (2018-04-10)
 
 
 ### Bug Fixes
 
-* **config:** add package name sanitisation ([#212](https://github.com/bucharest-gold/nodeshift/issues/212)) ([1c18b2a](https://github.com/bucharest-gold/nodeshift/commit/1c18b2a)), closes [#211](https://github.com/bucharest-gold/nodeshift/issues/211)
+* **config:** add package name sanitisation ([#212](https://github.com/nodeshift/nodeshift/issues/212)) ([1c18b2a](https://github.com/nodeshift/nodeshift/commit/1c18b2a)), closes [#211](https://github.com/nodeshift/nodeshift/issues/211)
 
 
 
 <a name="1.7.0"></a>
-# [1.7.0](https://github.com/bucharest-gold/nodeshift/compare/v1.6.0...v1.7.0) (2018-04-02)
+# [1.7.0](https://github.com/nodeshift/nodeshift/compare/v1.6.0...v1.7.0) (2018-04-02)
 
 
 ### Features
 
-* **build.env:** add a --build.env flag to specify build config environment variables ([0a43536](https://github.com/bucharest-gold/nodeshift/commit/0a43536)), closes [#208](https://github.com/bucharest-gold/nodeshift/issues/208)
+* **build.env:** add a --build.env flag to specify build config environment variables ([0a43536](https://github.com/nodeshift/nodeshift/commit/0a43536)), closes [#208](https://github.com/nodeshift/nodeshift/issues/208)
 
 
 
 <a name="1.6.0"></a>
-# [1.6.0](https://github.com/bucharest-gold/nodeshift/compare/v1.5.1...v1.6.0) (2018-03-22)
+# [1.6.0](https://github.com/nodeshift/nodeshift/compare/v1.5.1...v1.6.0) (2018-03-22)
 
 
 ### Features
 
-* Add an `--expose` flag which when true will create a default route and expose the default service ([6e06ec6](https://github.com/bucharest-gold/nodeshift/commit/6e06ec6))
+* Add an `--expose` flag which when true will create a default route and expose the default service ([6e06ec6](https://github.com/nodeshift/nodeshift/commit/6e06ec6))
 
 
 
 <a name="1.5.1"></a>
-## [1.5.1](https://github.com/bucharest-gold/nodeshift/compare/v1.5.0...v1.5.1) (2018-03-15)
+## [1.5.1](https://github.com/nodeshift/nodeshift/compare/v1.5.0...v1.5.1) (2018-03-15)
 
 
 ### Bug Fixes
 
-* **archiver:** fix for source archiver when no files property is found in the package.json ([3c856e8](https://github.com/bucharest-gold/nodeshift/commit/3c856e8)), closes [#200](https://github.com/bucharest-gold/nodeshift/issues/200)
+* **archiver:** fix for source archiver when no files property is found in the package.json ([3c856e8](https://github.com/nodeshift/nodeshift/commit/3c856e8)), closes [#200](https://github.com/nodeshift/nodeshift/issues/200)
 
 
 
 <a name="1.5.0"></a>
-# [1.5.0](https://github.com/bucharest-gold/nodeshift/compare/v1.4.1...v1.5.0) (2018-03-12)
+# [1.5.0](https://github.com/nodeshift/nodeshift/compare/v1.4.1...v1.5.0) (2018-03-12)
 
 
 ### Features
 
-* **config-loader:** expose the configLocation options for the openshift-config-loader. ([#198](https://github.com/bucharest-gold/nodeshift/issues/198)) ([7462ead](https://github.com/bucharest-gold/nodeshift/commit/7462ead)), closes [#197](https://github.com/bucharest-gold/nodeshift/issues/197)
+* **config-loader:** expose the configLocation options for the openshift-config-loader. ([#198](https://github.com/nodeshift/nodeshift/issues/198)) ([7462ead](https://github.com/nodeshift/nodeshift/commit/7462ead)), closes [#197](https://github.com/nodeshift/nodeshift/issues/197)
 
 
 
 <a name="1.4.1"></a>
-## [1.4.1](https://github.com/bucharest-gold/nodeshift/compare/v1.4.0...v1.4.1) (2018-03-02)
+## [1.4.1](https://github.com/nodeshift/nodeshift/compare/v1.4.0...v1.4.1) (2018-03-02)
 
 
 ### Bug Fixes
 
-* **nodeshift:** No longer check and emit a warning for non-standard Node versions. ([fa0c44e](https://github.com/bucharest-gold/nodeshift/commit/fa0c44e)), closes [#194](https://github.com/bucharest-gold/nodeshift/issues/194)
+* **nodeshift:** No longer check and emit a warning for non-standard Node versions. ([fa0c44e](https://github.com/nodeshift/nodeshift/commit/fa0c44e)), closes [#194](https://github.com/nodeshift/nodeshift/issues/194)
 
 
 
 <a name="1.4.0"></a>
-# [1.4.0](https://github.com/bucharest-gold/nodeshift/compare/v1.3.3...v1.4.0) (2018-02-21)
+# [1.4.0](https://github.com/nodeshift/nodeshift/compare/v1.3.3...v1.4.0) (2018-02-21)
 
 
 ### Features
 
-* undeploy: Add an option that, when true, will also remove builds, buildConfigs and Imagestreams ([#190](https://github.com/bucharest-gold/nodeshift/issues/190))([aebb5a1](https://github.com/bucharest-gold/nodeshift/commit/aebb5a1626f861e0143807d133ce8dc5b3ab767a))
+* undeploy: Add an option that, when true, will also remove builds, buildConfigs and Imagestreams ([#190](https://github.com/nodeshift/nodeshift/issues/190))([aebb5a1](https://github.com/nodeshift/nodeshift/commit/aebb5a1626f861e0143807d133ce8dc5b3ab767a))
 
 
 <a name="1.3.3"></a>
-## [1.3.3](https://github.com/bucharest-gold/nodeshift/compare/v1.3.2...v1.3.3) (2018-02-19)
+## [1.3.3](https://github.com/nodeshift/nodeshift/compare/v1.3.2...v1.3.3) (2018-02-19)
 
 
 
 <a name="1.3.2"></a>
-## [1.3.2](https://github.com/bucharest-gold/nodeshift/compare/v1.3.1...v1.3.2) (2018-02-13)
+## [1.3.2](https://github.com/nodeshift/nodeshift/compare/v1.3.1...v1.3.2) (2018-02-13)
 
 
 ### Bug Fixes
 
-* projectLocation should be set correctly. ([#189](https://github.com/bucharest-gold/nodeshift/issues/189)) ([4e061a9](https://github.com/bucharest-gold/nodeshift/commit/4e061a9)), closes [#188](https://github.com/bucharest-gold/nodeshift/issues/188)
+* projectLocation should be set correctly. ([#189](https://github.com/nodeshift/nodeshift/issues/189)) ([4e061a9](https://github.com/nodeshift/nodeshift/commit/4e061a9)), closes [#188](https://github.com/nodeshift/nodeshift/issues/188)
 
 
 
 <a name="1.3.1"></a>
-## [1.3.1](https://github.com/bucharest-gold/nodeshift/compare/v1.3.0...v1.3.1) (2018-02-12)
+## [1.3.1](https://github.com/nodeshift/nodeshift/compare/v1.3.0...v1.3.1) (2018-02-12)
 
 
 ### Bug Fixes
 
-* **nodeshift-config:** allow config properties to overwritten with new rest client update ([#187](https://github.com/bucharest-gold/nodeshift/issues/187)) ([9587efb](https://github.com/bucharest-gold/nodeshift/commit/9587efb))
+* **nodeshift-config:** allow config properties to overwritten with new rest client update ([#187](https://github.com/nodeshift/nodeshift/issues/187)) ([9587efb](https://github.com/nodeshift/nodeshift/commit/9587efb))
 
-* **route-spec** update route spec definition to not overwrite the spec:to:name property if one is specified. ([#185](https://github.com/bucharest-gold/nodeshift/pull/185)) fixes [#184](https://github.com/bucharest-gold/nodeshift/issues/184)
+* **route-spec** update route spec definition to not overwrite the spec:to:name property if one is specified. ([#185](https://github.com/nodeshift/nodeshift/pull/185)) fixes [#184](https://github.com/nodeshift/nodeshift/issues/184)
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Did you find a bug ?
 
-Open a [new issue](https://github.com/bucharest-gold/nodeshift/issues/new)
+Open a [new issue](https://github.com/nodeshift/nodeshift/issues/new)
 and be sure to include a title and clear description, as much relevant information
 as possible, and a code sample or a test case demonstrating the expected behavior
 that is not occurring.
@@ -15,13 +15,13 @@ Discussions can be done via github issues or IRC channel #brass-monkey.
 
 ### Fork
 
-Fork the project [on GitHub](https://github.com/bucharest-gold/nodeshift)
+Fork the project [on GitHub](https://github.com/nodeshift/nodeshift)
 and check out your copy locally.
 
 ```
 git clone git@github.com:username/nodeshift.git
 cd nodeshift
-git remote add upstream https://github.com/bucharest-gold/nodeshift.git
+git remote add upstream https://github.com/nodeshift/nodeshift.git
 ```
 
 ### Branch

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nodeshift [![Build Status](https://travis-ci.org/bucharest-gold/nodeshift.svg?branch=master)](https://travis-ci.org/bucharest-gold/nodeshift) [![Coverage Status](https://coveralls.io/repos/github/bucharest-gold/nodeshift/badge.svg?branch=master)](https://coveralls.io/github/bucharest-gold/nodeshift?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/bucharest-gold/nodeshift.svg)](https://greenkeeper.io/)
+# Nodeshift [![Build Status](https://travis-ci.org/nodeshift/nodeshift.svg?branch=master)](https://travis-ci.org/nodeshift/nodeshift) [![Coverage Status](https://coveralls.io/repos/github/nodeshift/nodeshift/badge.svg?branch=master)](https://coveralls.io/github/nodeshift/nodeshift?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/nodeshift/nodeshift.svg)](https://greenkeeper.io/)
 
 ## What is it
 
@@ -91,7 +91,7 @@ To set that using nodeshift, use the `-d` option with a KEY=VALUE, like this:
 
 Along with the command line, there is also a public API.  The API mirrors the commands.
 
-API Docs - https://bucharest-gold.github.io/nodeshift/
+API Docs - https://nodeshift.github.io/nodeshift/
 
 * resource
 
@@ -157,13 +157,13 @@ This option is passed through to the [Openshift Config Loader](https://www.npmjs
 #### nodeVersion - DEPRECATED
 This flag is now deprecated.  Please use imageTag instead.
 
-Specify the version of Node.js to use for the deployed application. defaults to latest.  These version tags corespond to the docker hub tags of the [bucharest-gold s2i images](https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/)
+Specify the version of Node.js to use for the deployed application. defaults to latest.  These version tags corespond to the docker hub tags of the [nodeshift s2i images](https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/)
 
 #### imageTag
-Specify the tag of the docker image to use for the deployed application. defaults to latest.  These version tags corespond to the docker hub tags of the [bucharest-gold s2i images](https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/)
+Specify the tag of the docker image to use for the deployed application. defaults to latest.  These version tags corespond to the docker hub tags of the [nodeshift s2i images](https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/)
 
 #### dockerImage
-Specify the s2i builder image of Node.js to use for the deployed applications.  Defaults to [bucharestgold/centos7-s2i-nodejs](https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs)
+Specify the s2i builder image of Node.js to use for the deployed applications.  Defaults to [nodeshift/centos7-s2i-nodejs](https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs)
 
 #### quiet
 supress INFO and TRACE lines from output logs.

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -53,7 +53,7 @@ yargs
     `
   })
   .options('dockerImage', {
-    describe: 'the s2i image to use, defaults to bucharest-gold/centos7-s2i-nodejs',
+    describe: 'the s2i image to use, defaults to nodeshift/centos7-s2i-nodejs',
     type: 'string'
   })
   .options('nodeVersion', {

--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ const cli = require('./bin/cli');
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
-  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
   @param {number} [options.deploy.port] - flag to update the default ports on the resource files. Defaults to 8080
@@ -46,8 +46,8 @@ function deploy (options = {}) {
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
-  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
@@ -69,8 +69,8 @@ function resource (options = {}) {
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
-  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
   @param {number} [options.deploy.port] - flag to update the default ports on the resource files. Defaults to 8080
@@ -94,8 +94,8 @@ function applyResource (options = {}) {
   @param {boolean} [options.strictSSL] - Set to false to allow self-signed Certs
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
-  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {boolean} [options.removeAll] - option to remove builds, buildConfigs and Imagestreams.  Defaults to false
   @param {object} [options.deploy] -
@@ -120,8 +120,8 @@ function undeploy (options = {}) {
   @param {boolean} [options.strictSSL] - Set to false to allow self-signed Certs
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
-  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false

--- a/lib/definitions/build-strategy.js
+++ b/lib/definitions/build-strategy.js
@@ -21,7 +21,7 @@
 const logger = require('../common-log')();
 
 // Perhaps we should define this in another location
-const DEFAULT_DOCKER_IMAGE = 'bucharestgold/centos7-s2i-nodejs';
+const DEFAULT_DOCKER_IMAGE = 'nodeshift/centos7-s2i-nodejs';
 const DEFAULT_DOCKER_TAG = 'latest';
 
 // https://docs.openshift.com/online/rest_api/openshift_v1.html#v1-buildstrategy

--- a/package.json
+++ b/package.json
@@ -30,15 +30,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "bucharest-gold/nodeshift.git"
+    "url": "nodeshift/nodeshift.git"
   },
   "keywords": [],
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/bucharest-gold/nodeshift/issues"
+    "url": "https://github.com/nodeshift/nodeshift/issues"
   },
-  "homepage": "https://github.com/bucharest-gold/nodeshift#readme",
+  "homepage": "https://github.com/nodeshift/nodeshift#readme",
   "dependencies": {
     "chalk": "^2.0.1",
     "git-repo-info": "^2.0.0",

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -20,7 +20,7 @@ while true; do
 done
 
 npm run docs
-git clone git@github.com:bucharest-gold/nodeshift.git $PUBLISH_DIR
+git clone git@github.com:nodeshift/nodeshift.git $PUBLISH_DIR
 cd $PUBLISH_DIR
 git checkout gh-pages
 mkdir version

--- a/test/build-strategy-test.js
+++ b/test/build-strategy-test.js
@@ -1,20 +1,20 @@
 const test = require('tape');
 const BuildStrategy = require('../lib/definitions/build-strategy');
 
-test('defaults to using the latest bucharestgold s2i builder image', t => {
+test('defaults to using the latest nodeshift s2i builder image', t => {
   const buildStrategy = BuildStrategy();
-  t.equals(buildStrategy.sourceStrategy.from.name, 'bucharestgold/centos7-s2i-nodejs:latest');
+  t.equals(buildStrategy.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:latest');
   t.end();
 });
 
 test('accepts a node version option', t => {
   const buildStrategy = BuildStrategy({ nodeVersion: '8.x' });
-  t.equals(buildStrategy.sourceStrategy.from.name, 'bucharestgold/centos7-s2i-nodejs:8.x');
+  t.equals(buildStrategy.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:8.x');
   t.end();
 });
 
 test('accepts a node version using imageTag option', t => {
   const buildStrategy = BuildStrategy({ imageTag: '8.x' });
-  t.equals(buildStrategy.sourceStrategy.from.name, 'bucharestgold/centos7-s2i-nodejs:8.x');
+  t.equals(buildStrategy.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:8.x');
   t.end();
 });

--- a/test/definitions-tests/build-strategy-test.js
+++ b/test/definitions-tests/build-strategy-test.js
@@ -7,7 +7,7 @@ test('default strategy', (t) => {
   const result = buildStrategy();
 
   t.equal(result.type, 'Source', 'default is Source type');
-  t.equal(result.sourceStrategy.from.name, 'bucharestgold/centos7-s2i-nodejs:latest', 'docker image should be latet BG gold image');
+  t.equal(result.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:latest', 'docker image should be latet BG gold image');
   t.equal(result.sourceStrategy.forcePull, undefined, 'no forcePull by default');
 
   t.end();
@@ -15,7 +15,7 @@ test('default strategy', (t) => {
 
 test('strategy with changed dockerTag', (t) => {
   const result = buildStrategy({ nodeVersion: '8.x' });
-  t.equal(result.sourceStrategy.from.name, 'bucharestgold/centos7-s2i-nodejs:8.x', 'docker image should be 8.x BG gold image');
+  t.equal(result.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:8.x', 'docker image should be 8.x BG gold image');
   t.end();
 });
 


### PR DESCRIPTION
BREAKING CHANGE: this now uses the nodeshift/centos7-s2i-nodejs image by default. This should be a semver major change.

fixes #268