### PR TITLE
fix: namespace.name spelling/parsing error

### DIFF
--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -95,7 +95,7 @@ yargs
     describe: 'flag to remove the user created namespace.  Only applicable for the undeploy command.  Must be used with namespace.name',
     type: 'boolean'
   })
-  .options('namesapce.name', {
+  .options('namespace.name', {
     describe: 'flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files',
     type: 'string'
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodeshift",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Plugin for running openshift deployments",
   "bin": {
     "nodeshift": "./bin/nodeshift"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodeshift",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "Plugin for running openshift deployments",
   "bin": {
     "nodeshift": "./bin/nodeshift"


### PR DESCRIPTION
Simple one, but caught me out by deploying my project into the wrong namespace 😆 
