### PR TITLE
feat: BREAKING CHANGE: remove the nodeVersion flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,6 @@ This option is passed through to the [Openshift Config Loader](https://www.npmjs
 #### tryServiceAccount
 This option is passed through to the [Openshift Config Loader](https://www.npmjs.com/package/openshift-config-loader). Set to false to by-pass service account lookup or use the KUBERNETES_AUTH_TRYSERVICEACCOUNT environment variable
 
-#### nodeVersion - DEPRECATED
-This flag is now deprecated.  Please use imageTag instead.
-
-Specify the version of Node.js to use for the deployed application. defaults to latest.  These version tags corespond to the docker hub tags of the [nodeshift s2i images](https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/)
-
 #### imageTag
 Specify the tag of the docker image to use for the deployed application. defaults to latest.  These version tags corespond to the docker hub tags of the [nodeshift s2i images](https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/)
 
@@ -213,11 +208,6 @@ Shows the below help
                                     Set to false to by-pass service account lookup
                                     or use the KUBERNETES_AUTH_TRYSERVICEACCOUNT
                                     environment variable
-
-            --nodeVersion, -n        the version of Node.js to use for the deployed
-                                    application.
-                    [string] [choices: "latest", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x"]
-                                                                        [default: "latest"]
             --imageTag           The tag of the docker image to use for the deployed
                                 application.                 [string] [default: "latest"]
             --quiet                  supress INFO and TRACE lines from output logs

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -56,11 +56,6 @@ yargs
     describe: 'the s2i image to use, defaults to nodeshift/centos7-s2i-nodejs',
     type: 'string'
   })
-  .options('nodeVersion', {
-    describe: 'DEPRECATED - use imageTag instead.  The version of Node.js to use for the deployed application.',
-    alias: 'n',
-    type: 'string'
-  })
   .options('imageTag', {
     describe: 'The tag of the docker image to use for the deployed application.',
     type: 'string',
@@ -163,12 +158,6 @@ function createOptions (argv) {
   options.projectLocation = argv.projectLocation;
   options.dockerImage = argv.dockerImage;
   options.imageTag = argv.imageTag;
-  // Remove during a major version release
-  if (argv.nodeVersion) {
-    console.log('DEPRECATION NOTICE - nodeVersion will be removed in the 2.0 release of Nodeshift. Please use imageTag instead.');
-    options.imageTag = argv.nodeVersion;
-  }
-  //
   process.env['NODESHIFT_QUIET'] = argv.quiet === true;
   options.metadata = argv.metadata;
   options.build = argv.build;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ const cli = require('./bin/cli');
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namesapce.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
@@ -53,7 +52,6 @@ function deploy (options = {}) {
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.namesapce.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.build] -
@@ -80,7 +78,6 @@ function resource (options = {}) {
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namesapce.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
@@ -109,7 +106,6 @@ function applyResource (options = {}) {
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.remove] - flag to remove the user created namespace.  Only applicable for the undeploy command.  Must be used with namespace.name
   @param {string} [options.namesapce.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {boolean} [options.removeAll] - option to remove builds, buildConfigs and Imagestreams.  Defaults to false
@@ -139,7 +135,6 @@ function undeploy (options = {}) {
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namesapce.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.build] -

--- a/lib/definitions/build-strategy.js
+++ b/lib/definitions/build-strategy.js
@@ -28,8 +28,7 @@ const DEFAULT_DOCKER_TAG = 'latest';
 module.exports = (options = {}) => {
   // Just doing the source strategy
   const dockerImage = options.dockerImage ? options.dockerImage : DEFAULT_DOCKER_IMAGE;
-  // remove the options.nodeVersion in 2.0
-  const dockerTag = options.imageTag ? options.imageTag : (options.nodeVersion ? options.nodeVersion : DEFAULT_DOCKER_TAG);
+  const dockerTag = options.imageTag ? options.imageTag : DEFAULT_DOCKER_TAG;
   logger.info(`Using s2i image ${dockerImage} with tag ${dockerTag}`);
   const dockerImageName = `${dockerImage}:${dockerTag}`;
   const env = options.buildEnv || [];

--- a/test/build-strategy-test.js
+++ b/test/build-strategy-test.js
@@ -7,12 +7,6 @@ test('defaults to using the latest nodeshift s2i builder image', t => {
   t.end();
 });
 
-test('accepts a node version option', t => {
-  const buildStrategy = BuildStrategy({ nodeVersion: '8.x' });
-  t.equals(buildStrategy.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:8.x');
-  t.end();
-});
-
 test('accepts a node version using imageTag option', t => {
   const buildStrategy = BuildStrategy({ imageTag: '8.x' });
   t.equals(buildStrategy.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:8.x');

--- a/test/definitions-tests/build-strategy-test.js
+++ b/test/definitions-tests/build-strategy-test.js
@@ -7,15 +7,15 @@ test('default strategy', (t) => {
   const result = buildStrategy();
 
   t.equal(result.type, 'Source', 'default is Source type');
-  t.equal(result.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:latest', 'docker image should be latet BG gold image');
+  t.equal(result.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:latest', 'docker image should be latet nodeshift image');
   t.equal(result.sourceStrategy.forcePull, undefined, 'no forcePull by default');
 
   t.end();
 });
 
 test('strategy with changed dockerTag', (t) => {
-  const result = buildStrategy({ nodeVersion: '8.x' });
-  t.equal(result.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:8.x', 'docker image should be 8.x BG gold image');
+  const result = buildStrategy({ imageTag: '8.x' });
+  t.equal(result.sourceStrategy.from.name, 'nodeshift/centos7-s2i-nodejs:8.x', 'docker image should be 8.x nodeshift image');
   t.end();
 });
 


### PR DESCRIPTION
* This has been marked as deprecated in 1.x and can be removed.

fixes #281