### PR TITLE
remove the string version of the namespace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,6 @@ Shows the below help
                                                                                 [boolean]
             --expose            flag to create a default Route and expose the default
                        service [boolean] [choices: true, false] [default: false]
-            --namespace              DEPRECATED - use object form instead.  flag to
-                           specify the project namespace to build/deploy into.
-                           Overwrites any namespace settings in your OpenShift
-                           or Kubernetes configuration files            [string]
             --namespace.displayName  flag to specify the project namespace display name to
                            build/deploy into.  Overwrites any namespace settings
                            in your OpenShift or Kubernetes configuration files

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -73,10 +73,6 @@ yargs
     type: 'boolean',
     default: false
   })
-  .options('namespace', {
-    describe: 'DEPRECATED - use object form instead.  flag to specify the project namespace to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files',
-    type: 'string'
-  })
   .options('namespace.displayName', {
     describe: 'flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files',
     type: 'string'

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const cli = require('./bin/cli');
   @param {boolean} [options.strictSSL] - Set to false to allow self-signed Certs
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
-  @param {string} [options.namespace(deprecated)] - DEPRECATED - use object form instead. Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
@@ -48,7 +47,6 @@ function deploy (options = {}) {
   @param {boolean} [options.strictSSL] - Set to false to allow self-signed Certs
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
-  @param {string} [options.namespace(deprecated)] - DEPRECATED - use object form instead. Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.namesapce.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
@@ -73,7 +71,6 @@ function resource (options = {}) {
   @param {boolean} [options.strictSSL] - Set to false to allow self-signed Certs
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
-  @param {string} [options.namespace(deprecated)] - DEPRECATED - use object form instead. Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
@@ -101,7 +98,6 @@ function applyResource (options = {}) {
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
   @param {boolean} [options.strictSSL] - Set to false to allow self-signed Certs
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
-  @param {string} [options.namespace(deprecated)] - DEPRECATED - use object form instead. Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.remove] - flag to remove the user created namespace.  Only applicable for the undeploy command.  Must be used with namespace.name
@@ -130,7 +126,6 @@ function undeploy (options = {}) {
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
   @param {boolean} [options.strictSSL] - Set to false to allow self-signed Certs
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
-  @param {string} [options.namespace(deprecated)] - DEPRECATED - use object form instead. Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name

--- a/lib/nodeshift-config.js
+++ b/lib/nodeshift-config.js
@@ -35,31 +35,8 @@ async function setup (options = {}) {
   const projectPackage = require(`${options.projectLocation}/package.json`);
   const config = await openshiftConfigLoader(Object.assign({}, { tryServiceAccount: options.tryServiceAccount, configLocation: options.configLocation }));
   if (options.namespace) {
-    // options.namespace can be either a String, Array or Object
-    // If it is an Array, Then if there is a value that is a string, that means the user specifed "--namespace=Name" and "--namespace.something=ELSE", we are deprecating just the string form, but we need to take this into account
-    if (Array.isArray(options.namespace)) {
-      // Map the values and then convert to an object using spread
-      options.namespace = Object.assign({}, ...options.namespace.map((n) => {
-        if (typeof n === 'string') {
-          return { _name: n };
-        }
-        return n;
-      }));
-
-      options.namespace.name = options.namespace.name ? options.namespace.name : options.namespace._name;
-    } else if (typeof options.namespace === 'object') {
-      // If the value is an Object, then they are specifying things.  And at name is required.
-      if (!options.namespace.name) {
-        throw new Error('namespace.name must be specified when using the --namespace flag');
-      }
-    } else {
-      // It is a string, then just "--namespace=NAME" was used, this is deprecated
-      logger.warning('--namespace=NAME is deprecated, please use object form.  ex: --namespace.name=NAME');
-      options.namespace = {
-        create: false,
-        displayName: options.namespace,
-        name: options.namespace
-      };
+    if (!options.namespace.name) {
+      throw new Error('namespace.name must be specified when using the --namespace flag');
     }
 
     // Add this userDefined property that will be used during undeploy
@@ -67,7 +44,6 @@ async function setup (options = {}) {
     // Need to remove any spaces and convert to lowe case
     options.namespace.name = options.namespace.name.replace(/\s+/g, '').toLowerCase();
     // A user is overriding the namespace
-    // convert options.namespce into an object for later use
     config.context.namespace = options.namespace.name;
   }
 

--- a/test/nodeshift-config-test.js
+++ b/test/nodeshift-config-test.js
@@ -212,7 +212,9 @@ test('nodeshift-config options for the config loader - change the namespace', (t
   });
 
   const options = {
-    namespace: 'foo'
+    namespace: {
+      name: 'foo'
+    }
   };
 
   nodeshiftConfig(options).then((config) => {
@@ -236,7 +238,9 @@ test('nodeshift-config options for the config loader - change the namespace, for
   });
 
   const options = {
-    namespace: 'New Project'
+    namespace: {
+      name: 'New Project'
+    }
   };
 
   nodeshiftConfig(options).then((config) => {
@@ -292,67 +296,6 @@ test('nodeshift-config options for the config loader - using namespace object fo
 
   nodeshiftConfig(options).then((config) => {
     t.equal(config.context.namespace, 'funproject', 'context and options namespace should be the same');
-    t.equal(config.namespace.userDefined, true, 'should have the user defined variable');
-    t.equal(config.namespace.displayName, options.namespace.displayName, 'should have the displayName');
-    t.end();
-  });
-});
-
-// This test is a little contrived since someone using the API would probably never do this
-// This is just testing what the CLI would provide is someone used --namespace=VALUE and --namespace.displayName=VALUE for instance
-test('nodeshift-config options for the config loader - using namespace as a string and object, provide name', (t) => {
-  const nodeshiftConfig = proxyquire('../lib/nodeshift-config', {
-    'openshift-config-loader': (options) => {
-      return Promise.resolve({
-        context: {
-          namespace: 'test-namespace'
-        },
-        cluster: 'http://mock-cluster'
-      });
-    },
-    'openshift-rest-client': () => { return Promise.resolve({}); }
-  });
-
-  const options = {
-    namespace: ['Name', {
-      displayName: 'New Project',
-      name: 'Project Name'
-    }]
-  };
-
-  nodeshiftConfig(options).then((config) => {
-    t.equal(config.context.namespace, 'projectname', 'context and options namespace should be the same');
-    t.equal(config.namespace._name, 'Name', 'should have the "private" _name field');
-    t.equal(config.namespace.userDefined, true, 'should have the user defined variable');
-    t.equal(config.namespace.displayName, options.namespace.displayName, 'should have the displayName');
-    t.end();
-  });
-});
-
-// This test is a little contrived since someone using the API would probably never do this
-// This is just testing what the CLI would provide is someone used --namespace=VALUE and --namespace.displayName=VALUE for instance
-test('nodeshift-config options for the config loader - using namespace as a string and object, provide name', (t) => {
-  const nodeshiftConfig = proxyquire('../lib/nodeshift-config', {
-    'openshift-config-loader': (options) => {
-      return Promise.resolve({
-        context: {
-          namespace: 'test-namespace'
-        },
-        cluster: 'http://mock-cluster'
-      });
-    },
-    'openshift-rest-client': () => { return Promise.resolve({}); }
-  });
-
-  const options = {
-    namespace: ['Name', {
-      displayName: 'New Project'
-    }]
-  };
-
-  nodeshiftConfig(options).then((config) => {
-    t.equal(config.context.namespace, 'name', 'context and options namespace should be the same');
-    t.equal(config.namespace._name, 'Name', 'should have the "private" _name field');
     t.equal(config.namespace.userDefined, true, 'should have the user defined variable');
     t.equal(config.namespace.displayName, options.namespace.displayName, 'should have the displayName');
     t.end();


### PR DESCRIPTION
Just doing `--namespace=name` has been deprecated for a while and needs to be removed. 

It is recommended to use the format `--namespace.name`


connects to #282 