### PR TITLE
fix: load the projectLocation not relative to the nodeshift-config.js…

### DIFF
--- a/lib/nodeshift-config.js
+++ b/lib/nodeshift-config.js
@@ -21,6 +21,9 @@
 const logger = require('./common-log')();
 const openshiftConfigLoader = require('openshift-config-loader');
 const restClient = require('openshift-rest-client');
+const fs = require('fs');
+const { promisify } = require('util');
+const readFile = promisify(fs.readFile);
 
 /**
   This module will attempt to load the Openshift configuration using the openshift-config-loader module. https://www.npmjs.com/package/openshift-config-loader
@@ -32,7 +35,7 @@ async function setup (options = {}) {
   options.projectLocation = options.projectLocation || process.cwd();
 
   logger.info('loading configuration');
-  const projectPackage = require(`${options.projectLocation}/package.json`);
+  const projectPackage = JSON.parse(await readFile(`${options.projectLocation}/package.json`, { encoding: 'utf8' }));
   const config = await openshiftConfigLoader(Object.assign({}, { tryServiceAccount: options.tryServiceAccount, configLocation: options.configLocation }));
   if (options.namespace) {
     if (!options.namespace.name) {

--- a/test/nodeshift-config-test.js
+++ b/test/nodeshift-config-test.js
@@ -71,11 +71,11 @@ test('nodeshift-config other project location and nodeshiftDir', (t) => {
   });
 
   const options = {
-    projectLocation: '../examples/sample-project'
+    projectLocation: './examples/sample-project'
   };
 
   nodeshiftConfig(options).then((config) => {
-    t.equal(config.projectLocation, '../examples/sample-project', 'projectLocation prop should be changed');
+    t.equal(config.projectLocation, './examples/sample-project', 'projectLocation prop should be changed');
     t.end();
   });
 });
@@ -94,7 +94,7 @@ test('nodeshift-config no project Version', (t) => {
   });
 
   const options = {
-    projectLocation: '../examples/sample-project-no-version'
+    projectLocation: './examples/sample-project-no-version'
   };
 
   nodeshiftConfig(options).then((config) => {
@@ -121,7 +121,7 @@ test('nodeshift-config no package.json', (t) => {
   };
 
   nodeshiftConfig(options).catch((err) => {
-    t.equal(err.message.includes('Cannot find module \'./not-here/package.json\''), true, 'Error Should be "\'Cannot find module \'./not-here/package.json\'\'"');
+    t.equal(err.message.includes('./not-here/package.json'), true, 'Error Should be "\'Cannot find module \'./not-here/package.json\'\'"');
     t.end();
   });
 });


### PR DESCRIPTION
… file

* This makes it so you don't need to use the full directory path when specifing the projectLocation.

* project location will be loaded relative to your current working directory.

fixes #301