### PR TITLE
chore: docs should be updated with the correct version number during …

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "docs": "documentation build index.js --shallow -f html -o docs --config documentation.yml",
     "ci": "npm run lint && npm run coveralls",
-    "prerelease": "npm run lint && npm run test && npm run docs",
+    "prerelease": "npm run lint && npm run test",
     "release": "standard-version -a"
   },
   "standard-version": {
     "scripts": {
+      "postbump": "npm run docs",
       "precommit": "git add docs/"
     }
   },


### PR DESCRIPTION
…a release

* Adding the postbump release script allows the docs to be generated after the package.json version bump

fixes #326