### PR TITLE
feat: change the output Image Stream name and tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Specify the tag of the docker image to use for the deployed application. default
 Specify the s2i builder image of Node.js to use for the deployed applications.  Defaults to [nodeshift/centos7-s2i-nodejs](https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs)
 
 #### outputImageStream
-The name of the Image Stream to output to.  Defualts to project name from package.json
+The name of the Image Stream to output to.  Defaults to project name from package.json
 
 #### outputImageStreamTag
 The Tag of the Image Stream to output to. Defaults to latest
@@ -205,7 +205,7 @@ Shows the below help
             --projectLocation        change the default location of the project   [string]
             --imageTag           The tag of the docker image to use for the deployed
                                 application.                 [string] [default: "latest"]
-            --outputImageStream      The name of the Image Stream to output to.  Defualts
+            --outputImageStream      The name of the Image Stream to output to.  Defaults
                            to project name from package.json            [string]
             --outputImageStreamTag   The Tag of the Image Stream to output to.    [string]
             --quiet                  suppress INFO and TRACE lines from output logs

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Specify the tag of the docker image to use for the deployed application. default
 #### dockerImage
 Specify the s2i builder image of Node.js to use for the deployed applications.  Defaults to [nodeshift/centos7-s2i-nodejs](https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs)
 
+#### outputImageStream
+The name of the Image Stream to output to.  Defualts to project name from package.json
+
+#### outputImageStreamTag
+The Tag of the Image Stream to output to. Defaults to latest
+
 #### quiet
 suppress INFO and TRACE lines from output logs.
 
@@ -199,6 +205,9 @@ Shows the below help
             --projectLocation        change the default location of the project   [string]
             --imageTag           The tag of the docker image to use for the deployed
                                 application.                 [string] [default: "latest"]
+            --outputImageStream      The name of the Image Stream to output to.  Defualts
+                           to project name from package.json            [string]
+            --outputImageStreamTag   The Tag of the Image Stream to output to.    [string]
             --quiet                  suppress INFO and TRACE lines from output logs
                                                                                 [boolean]
             --expose            flag to create a default Route and expose the default

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ Specify the tag of the docker image to use for the deployed application. default
 Specify the s2i builder image of Node.js to use for the deployed applications.  Defaults to [nodeshift/centos7-s2i-nodejs](https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs)
 
 #### outputImageStream
-The name of the Image Stream to output to.  Defaults to project name from package.json
+The name of the ImageStream to output to.  Defaults to project name from package.json
 
 #### outputImageStreamTag
-The Tag of the Image Stream to output to. Defaults to latest
+The tag of the ImageStream to output to. Defaults to latest
 
 #### quiet
 suppress INFO and TRACE lines from output logs.
@@ -205,9 +205,9 @@ Shows the below help
             --projectLocation        change the default location of the project   [string]
             --imageTag           The tag of the docker image to use for the deployed
                                 application.                 [string] [default: "latest"]
-            --outputImageStream      The name of the Image Stream to output to.  Defaults
+            --outputImageStream      The name of the ImageStream to output to.  Defaults
                            to project name from package.json            [string]
-            --outputImageStreamTag   The Tag of the Image Stream to output to.    [string]
+            --outputImageStreamTag   The tag of the ImageStream to output to.    [string]
             --quiet                  suppress INFO and TRACE lines from output logs
                                                                                 [boolean]
             --expose            flag to create a default Route and expose the default

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -54,7 +54,7 @@ yargs
     default: 'latest'
   })
   .options('outputImageStream', {
-    describe: 'The name of the Image Stream to output to.  Defualts to project name from package.json',
+    describe: 'The name of the Image Stream to output to.  Defaults to project name from package.json',
     type: 'string'
   })
   .options('outputImageStreamTag', {

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -54,11 +54,11 @@ yargs
     default: 'latest'
   })
   .options('outputImageStream', {
-    describe: 'The name of the Image Stream to output to.  Defaults to project name from package.json',
+    describe: 'The name of the ImageStream to output to.  Defaults to project name from package.json',
     type: 'string'
   })
   .options('outputImageStreamTag', {
-    describe: 'The Tag of the Image Stream to output to.',
+    describe: 'The tag of the ImageStream to output to.',
     type: 'string',
     defualt: 'latest'
   })

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -53,6 +53,15 @@ yargs
     type: 'string',
     default: 'latest'
   })
+  .options('outputImageStream', {
+    describe: 'The name of the Image Stream to output to.  Defualts to project name from package.json',
+    type: 'string'
+  })
+  .options('outputImageStreamTag', {
+    describe: 'The Tag of the Image Stream to output to.',
+    type: 'string',
+    defualt: 'latest'
+  })
   .env('NODESHIFT')
   .option('quiet', {
     describe: 'suppress INFO and TRACE lines from output logs',
@@ -146,6 +155,8 @@ function createOptions (argv) {
   options.projectLocation = argv.projectLocation;
   options.dockerImage = argv.dockerImage;
   options.imageTag = argv.imageTag;
+  options.outputImageStreamName = argv.outputImageStream;
+  options.outputImageStreamTag = argv.outputImageStreamTag;
   process.env['NODESHIFT_QUIET'] = argv.quiet === true;
   options.metadata = argv.metadata;
   options.build = argv.build;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const cli = require('./bin/cli');
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
   @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
@@ -47,7 +47,7 @@ function deploy (options = {}) {
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
   @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.build] -
@@ -72,7 +72,7 @@ function resource (options = {}) {
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
   @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
@@ -99,7 +99,7 @@ function applyResource (options = {}) {
   @param {boolean} [options.namespace.remove] - flag to remove the user created namespace.  Only applicable for the undeploy command.  Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
   @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {boolean} [options.removeAll] - option to remove builds, buildConfigs and Imagestreams.  Defaults to false
@@ -127,7 +127,7 @@ function undeploy (options = {}) {
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
   @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.build] -

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ const cli = require('./bin/cli');
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
   @param {number} [options.deploy.port] - flag to update the default ports on the resource files. Defaults to 8080
@@ -45,6 +47,8 @@ function deploy (options = {}) {
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
@@ -68,6 +72,8 @@ function resource (options = {}) {
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
   @param {number} [options.deploy.port] - flag to update the default ports on the resource files. Defaults to 8080
@@ -93,6 +99,8 @@ function applyResource (options = {}) {
   @param {boolean} [options.namespace.remove] - flag to remove the user created namespace.  Only applicable for the undeploy command.  Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {boolean} [options.removeAll] - option to remove builds, buildConfigs and Imagestreams.  Defaults to false
   @param {object} [options.deploy] -
@@ -119,6 +127,8 @@ function undeploy (options = {}) {
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
+  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defualts to project name from package.json
+  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false

--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ const cli = require('./bin/cli');
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
-  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
+  @param {string} [options.outputImageStream] - the name of the ImageStream to output to.  Defaults to project name from package.json
+  @param {string} [options.outputImageTag] - The tag of the ImageStream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
   @param {number} [options.deploy.port] - flag to update the default ports on the resource files. Defaults to 8080
@@ -47,8 +47,8 @@ function deploy (options = {}) {
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
-  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
+  @param {string} [options.outputImageStream] - the name of the ImageStream to output to.  Defaults to project name from package.json
+  @param {string} [options.outputImageTag] - The tag of the ImageStream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
@@ -72,8 +72,8 @@ function resource (options = {}) {
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
-  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
+  @param {string} [options.outputImageStream] - the name of the ImageStream to output to.  Defaults to project name from package.json
+  @param {string} [options.outputImageTag] - The tag of the ImageStream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
   @param {number} [options.deploy.port] - flag to update the default ports on the resource files. Defaults to 8080
@@ -99,8 +99,8 @@ function applyResource (options = {}) {
   @param {boolean} [options.namespace.remove] - flag to remove the user created namespace.  Only applicable for the undeploy command.  Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
-  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
+  @param {string} [options.outputImageStream] - the name of the ImageStream to output to.  Defaults to project name from package.json
+  @param {string} [options.outputImageTag] - The tag of the ImageStream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {boolean} [options.removeAll] - option to remove builds, buildConfigs and Imagestreams.  Defaults to false
   @param {object} [options.deploy] -
@@ -127,8 +127,8 @@ function undeploy (options = {}) {
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.imageTag] - set the version to use for the nodeshift/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/nodeshift/centos7-s2i-nodejs/tags/
-  @param {string} [options.outputImageStream] - the name of the Image Stream to output to.  Defaults to project name from package.json
-  @param {string} [options.outputImageTag] - The Tag of the Image Stream to output to. Defaults to latest
+  @param {string} [options.outputImageStream] - the name of the ImageStream to output to.  Defaults to project name from package.json
+  @param {string} [options.outputImageTag] - The tag of the ImageStream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -78,8 +78,7 @@ async function removeBuildsAndBuildConfig (config) {
 async function createOrUpdateBuildConfig (config) {
   // Check for a BuildConfig, create or update if necessary
   const buildName = config.buildName;
-  const imageStreamName = config.projectName;
-  const outputImageStreamTag = `${imageStreamName}:latest`; // TODO: base on a tag
+  const outputImageStreamTag = `${config.outputImageStreamName}:latest`; // TODO: base on a tag
   // The new code under the openshift rest client, returns an error when getting a 404, so we need to catch it and check the status code
   // I wonder if it is better to find all buildConfigs, then do a Array.find on the returned item list
   const buildConfig = await awaitRequest(config.openshiftRestClient.apis.build.v1.ns(config.namespace.name).buildconfigs(buildName).get());

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -78,7 +78,7 @@ async function removeBuildsAndBuildConfig (config) {
 async function createOrUpdateBuildConfig (config) {
   // Check for a BuildConfig, create or update if necessary
   const buildName = config.buildName;
-  const outputImageStreamTag = `${config.outputImageStreamName}:latest`; // TODO: base on a tag
+  const outputImageStreamTag = `${config.outputImageStreamName}:${config.outputImageStreamTag}`;
   // The new code under the openshift rest client, returns an error when getting a 404, so we need to catch it and check the status code
   // I wonder if it is better to find all buildConfigs, then do a Array.find on the returned item list
   const buildConfig = await awaitRequest(config.openshiftRestClient.apis.build.v1.ns(config.namespace.name).buildconfigs(buildName).get());

--- a/lib/definitions/container.js
+++ b/lib/definitions/container.js
@@ -28,7 +28,7 @@ module.exports = (resource, config) => {
   }
 
   const container = {
-    image: config.projectName,
+    image: config.outputImageStreamName,
     name: config.projectName,
     securityContext: {
       privileged: false

--- a/lib/definitions/deployment-config-spec.js
+++ b/lib/definitions/deployment-config-spec.js
@@ -53,7 +53,7 @@ module.exports = (resource, config) => {
         from: {
           kind: 'ImageStreamTag',
           namespace: config.namespace.name,
-          name: `${config.projectName}:latest`
+          name: `${config.outputImageStreamName}:${config.outputImageStreamTag}`
         }
       }
     }

--- a/lib/image-stream.js
+++ b/lib/image-stream.js
@@ -50,7 +50,7 @@ async function createOrUpdateImageStream (config) {
   const imageStream = await awaitRequest(config.openshiftRestClient.apis.image.v1.ns(config.namespace.name).imagestreams(config.outputImageStreamName).get());
   if (imageStream.code === 404) {
     // Need to create the image stream
-    logger.info(`creating image stream ${config.outputImageStreamName}`);
+    logger.info(`creating ImageStream ${config.outputImageStreamName}`);
     return config.openshiftRestClient.apis.image.v1.ns(config.namespace.name).imagestreams.post({ body: createImageStream(config) });
   }
 
@@ -59,7 +59,7 @@ async function createOrUpdateImageStream (config) {
 
     await removeImageStream(config);
 
-    logger.info(`Re-creating image stream ${config.outputImageStreamName}`);
+    logger.info(`Re-creating ImageStream ${config.outputImageStreamName}`);
     return config.openshiftRestClient.apis.image.v1.ns(config.namespace.name).imagestreams.post({ body: createImageStream(config) });
   }
 
@@ -68,7 +68,7 @@ async function createOrUpdateImageStream (config) {
 }
 
 function removeImageStream (config) {
-  logger.info(`Deleting Image Stream ${config.outputImageStreamName}`);
+  logger.info(`Deleting ImageStream ${config.outputImageStreamName}`);
 
   // Some default remove Body Options for the rest client, maybe at some point, these will be exposed to the user
   const removeOptions = {

--- a/lib/image-stream.js
+++ b/lib/image-stream.js
@@ -35,7 +35,7 @@ function createImageStream (config, options) {
 
   // Add new metadata
   imageStream.metadata = objectMetadata({
-    name: config.projectName,
+    name: config.outputImageStreamName,
     namespace: config.namespace.name,
     labels: {
       project: config.projectName,
@@ -47,10 +47,10 @@ function createImageStream (config, options) {
 }
 
 async function createOrUpdateImageStream (config) {
-  const imageStream = await awaitRequest(config.openshiftRestClient.apis.image.v1.ns(config.namespace.name).imagestreams(config.projectName).get());
+  const imageStream = await awaitRequest(config.openshiftRestClient.apis.image.v1.ns(config.namespace.name).imagestreams(config.outputImageStreamName).get());
   if (imageStream.code === 404) {
     // Need to create the image stream
-    logger.info(`creating image stream ${config.projectName}`);
+    logger.info(`creating image stream ${config.outputImageStreamName}`);
     return config.openshiftRestClient.apis.image.v1.ns(config.namespace.name).imagestreams.post({ body: createImageStream(config) });
   }
 
@@ -59,16 +59,16 @@ async function createOrUpdateImageStream (config) {
 
     await removeImageStream(config);
 
-    logger.info(`Re-creating image stream ${config.projectName}`);
+    logger.info(`Re-creating image stream ${config.outputImageStreamName}`);
     return config.openshiftRestClient.apis.image.v1.ns(config.namespace.name).imagestreams.post({ body: createImageStream(config) });
   }
 
-  logger.info(`using existing image stream ${config.projectName}`);
+  logger.info(`using existing image stream ${config.outputImageStreamName}`);
   return imageStream;
 }
 
 function removeImageStream (config) {
-  logger.info(`Deleting Image Stream ${config.projectName}`);
+  logger.info(`Deleting Image Stream ${config.outputImageStreamName}`);
 
   // Some default remove Body Options for the rest client, maybe at some point, these will be exposed to the user
   const removeOptions = {
@@ -79,7 +79,7 @@ function removeImageStream (config) {
   };
 
   // delete image stream
-  return awaitRequest(config.openshiftRestClient.apis.image.v1.ns(config.namespace.name).imagestreams(config.projectName).delete({ body: removeOptions }));
+  return awaitRequest(config.openshiftRestClient.apis.image.v1.ns(config.namespace.name).imagestreams(config.outputImageStreamName).delete({ body: removeOptions }));
 }
 
 module.exports = {

--- a/lib/nodeshift-config.js
+++ b/lib/nodeshift-config.js
@@ -61,7 +61,7 @@ async function setup (options = {}) {
   }
 
   options.outputImageStreamName = options.outputImageStreamName || projectPackage.name;
-  options.outputImageStreamTag = 'latest';
+  options.outputImageStreamTag = options.outputImageStreamTag || 'latest';
   // Return a new object with the config, the rest client and other data.
   return Object.assign({}, config, {
     projectPackage,

--- a/lib/nodeshift-config.js
+++ b/lib/nodeshift-config.js
@@ -60,6 +60,8 @@ async function setup (options = {}) {
     throw new Error('"name" in package.json can only consist lower-case letters, numbers, and dashes. It must start with a letter and can\'t end with a -.');
   }
 
+  options.outputImageStreamName = options.outputImageStreamName || projectPackage.name;
+  options.outputImageStreamTag = 'latest';
   // Return a new object with the config, the rest client and other data.
   return Object.assign({}, config, {
     projectPackage,

--- a/test/definitions-tests/deployment-config-spec-test.js
+++ b/test/definitions-tests/deployment-config-spec-test.js
@@ -11,6 +11,8 @@ test('deployment-config-spec test', (t) => {
   const resource = {};
   const config = {
     projectName: 'project1',
+    outputImageStreamName: 'project1',
+    outputImageStreamTag: 'latest',
     namespace: {
       name: 'project-namespace'
     }

--- a/test/image-stream-test.js
+++ b/test/image-stream-test.js
@@ -54,7 +54,7 @@ test('create imageStream not found', (t) => {
     './common-log': () => {
       return {
         info: (info) => {
-          t.equal(info, 'creating image stream project-name', 'should have the correct info message');
+          t.equal(info, 'creating ImageStream project-name', 'should have the correct info message');
           return info;
         }
       };

--- a/test/image-stream-test.js
+++ b/test/image-stream-test.js
@@ -14,6 +14,7 @@ test('create imageStream not found', (t) => {
   let call = 0;
   const config = {
     projectName: 'project-name',
+    outputImageStreamName: 'project-name',
     namespace: {
       name: ''
     },
@@ -69,6 +70,7 @@ test('buildConfig found - no recreate', (t) => {
   const config = {
     buildName: 'nodejs-s2i-build',
     projectName: 'project-name',
+    outputImageStreamName: 'project-name',
     version: '1.0.0',
     namespace: {
       name: ''
@@ -117,6 +119,7 @@ test('imagestream recreate but is a buildConfig', (t) => {
     },
     buildName: 'nodejs-s2i-build',
     projectName: 'project-name',
+    outputImageStreamName: 'project-name',
     version: '1.0.0',
     namespace: {
       name: ''

--- a/test/nodeshift-config-test.js
+++ b/test/nodeshift-config-test.js
@@ -27,6 +27,8 @@ test('nodeshift-config basic setup', (t) => {
     t.equal(config.projectLocation, process.cwd(), 'projectLocation prop should be cwd by default');
     t.ok(config.nodeshiftDirectory, 'nodeshiftDir prop should be here');
     t.equal(config.nodeshiftDirectory, '.nodeshift', 'nodeshiftDir prop should be .nodeshift by default');
+    t.equal(config.outputImageStreamName, 'nodeshift', 'outputImageStreamName should be the package name by default');
+    t.equal(config.outputImageStreamTag, 'latest', 'outputImageStreamTag should be the latest by default');
     t.end();
   }).catch(t.fail);
 
@@ -339,6 +341,35 @@ test('nodeshift-config options for the config loader - using namespace object fo
     t.equal(config.namespace.name, 'funproject', 'context and options namespace should be the same');
     t.equal(config.namespace.userDefined, true, 'should have the user defined variable');
     t.equal(config.namespace.displayName, options.namespace.displayName, 'should have the displayName');
+    t.end();
+  });
+});
+
+test('nodeshift-config options - change outputImageStreamTag and outputImageStreamName', (t) => {
+  const nodeshiftConfig = proxyquire('../lib/nodeshift-config', {
+    'openshift-rest-client': {
+      config: {
+        fromKubeconfig: () => {
+          return {
+            namespace: 'test-namespace',
+            url: 'http://mock-cluster'
+          };
+        }
+      },
+      OpenshiftClient: () => {
+        return Promise.resolve();
+      }
+    }
+  });
+
+  const options = {
+    outputImageStreamName: 'funTimes',
+    outputImageStreamTag: 'notLatest'
+  };
+
+  nodeshiftConfig(options).then((config) => {
+    t.equal(config.outputImageStreamTag, options.outputImageStreamTag, 'should not be latest');
+    t.equal(config.outputImageStreamName, options.outputImageStreamName, 'should not be the project name');
     t.end();
   });
 });


### PR DESCRIPTION
fixes #337

@lance when you get a chance,  you want to test this out.

I still need to added tests and update the readme and and stuff.  but the functionality should all be there

there are now  `--outputImageStream` and `--outputImageStreamTag`  flags to specify the different output stream names and tag