### PR TITLE
chore: remove eslint fix by default.

### DIFF
--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -157,7 +157,7 @@ function createOptions (argv) {
   options.imageTag = argv.imageTag;
   options.outputImageStreamName = argv.outputImageStream;
   options.outputImageStreamTag = argv.outputImageStreamTag;
-  process.env['NODESHIFT_QUIET'] = argv.quiet === true;
+  process.env.NODESHIFT_QUIET = argv.quiet === true;
   options.metadata = argv.metadata;
   options.build = argv.build;
   options.deploy = argv.deploy;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "nodeshift": "./bin/nodeshift"
   },
   "scripts": {
-    "lint": "eslint --fix bin/* lib/**/*.js test/*-test.js test/**/*-test.js index.js",
+    "lint": "eslint bin/* lib/**/*.js test/*-test.js test/**/*-test.js index.js",
     "test": "cross-env NODESHIFT_QUIET=true tape test/*-test.js test/**/*-test.js | tap-spec",
     "coverage": "nyc npm test",
     "coverage:html": "nyc npm test && nyc report --reporter=html",

--- a/test/enricher-tests/git-info-enricher-test.js
+++ b/test/enricher-tests/git-info-enricher-test.js
@@ -180,10 +180,10 @@ test('git-info-enricher - deploymentConfig - merge test', async (t) => {
   t.ok(list[0].metadata.annotations, 'annotations');
   t.equal(list[0].metadata.annotations['nodeshift/git-branch'], 'master', 'branch prop is master');
   t.equal(list[0].metadata.annotations['nodeshift/git-commit'], 'abcd1234', 'commit prop is abcd1234');
-  t.equal(list[0].metadata.annotations['key'], 'value', 'commit prop is abcd1234');
+  t.equal(list[0].metadata.annotations.key, 'value', 'commit prop is abcd1234');
   t.ok(list[0].spec.template.metadata.annotations, 'annotations');
   t.equal(list[0].spec.template.metadata.annotations['nodeshift/git-branch'], 'master', 'branch prop is master');
   t.equal(list[0].spec.template.metadata.annotations['nodeshift/git-commit'], 'abcd1234', 'commit prop is abcd1234');
-  t.equal(list[0].spec.template.metadata.annotations['key'], 'value', 'commit prop is abcd1234');
+  t.equal(list[0].spec.template.metadata.annotations.key, 'value', 'commit prop is abcd1234');
   t.end();
 });


### PR DESCRIPTION
* since the --fix flag was being run, we weren't getting errors on CI that linting was broken.  When i was trying to do a release, i noticed that there were some un staged files after doing the release script.

* removing the --fix flag, so we don't get false positives