### PR TITLE
fix: promisifying the newest release of mkdirp breaks mkdirp.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -46,7 +46,7 @@ function normalizeFileList (fileList, projectLocation) {
 }
 
 function createDir (directoryToCreate) {
-  return promisify(mkdirp)(directoryToCreate);
+  return mkdirp(directoryToCreate);
 }
 
 function cleanUp (directoryToClean) {

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -16,8 +16,8 @@ test('checks existing and nonexistent files', (t) => {
 
 test('test createDir function - success', (t) => {
   const helpers = proxyquire('../lib/helpers', {
-    mkdirp: (dir, cb) => {
-      return cb();
+    mkdirp: (dir) => {
+      return Promise.resolve();
     }
   });
 
@@ -33,8 +33,8 @@ test('test createDir function - success', (t) => {
 
 test('test createDir function - fail', (t) => {
   const helpers = proxyquire('../lib/helpers', {
-    mkdirp: (dir, cb) => {
-      return cb(new Error('Error: error creating directory'));
+    mkdirp: (dir) => {
+      return Promise.reject(new Error('Error: error creating directory'));
     }
   });
 


### PR DESCRIPTION
The most recent version(1.0.3) of mkdirp actual returns a promise, so there is no need to return a promise now

fixes #411