### PR TITLE
feat(build-strategy): Add Docker build strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ Flag to perform incremental builds(if applicable), which means it reuses artifac
 #### build.env
 Flag to pass build config environment variables as NAME=Value.  Can be used multiple times.  ex: `nodeshift --build.env NODE_ENV=development --build.env YARN_ENABLED=true`
 
+#### build.strategy
+Flag to change the build strategy used.  Values can be Docker or Source.  Defaults to Source
+
 #### help
 Shows the below help
 
@@ -244,6 +247,8 @@ Shows the below help
             --build.incremental  flag to perform incremental builds, which means it reuses
                                     artifacts from previously-built images
                                         [boolean] [choices: true, false] [default: false]
+            --build.strategy         flag to change the build strategy.  Defaults to Source
+                                      [choices: "Source", "Docker"]
             --metadata.out           determines what should be done with the response
                                     metadata from OpenShift
                     [string] [choices: "stdout", "ignore", "<filename>"] [default: "ignore"]

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -117,6 +117,10 @@ yargs
     type: 'boolean',
     default: false
   })
+  .options('build.strategy', {
+    describe: 'flag to change the build strategy.  Defaults to Source',
+    choices: ['Source', 'Docker']
+  })
   .array('build.env')
   .options('metadata.out', {
     describe: 'determines what should be done with the response metadata from OpenShift',

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const cli = require('./bin/cli');
   @param {number} [options.deploy.port] - flag to update the default ports on the resource files. Defaults to 8080
   @param {Array} [options.deploy.env] - an array of objects to pass deployment config environment variables.  [{name: NAME_PROP, value: VALUE}]
   @param {object} [options.build] -
+  @param {string} [options.build.strategy] - flag to change the build strategy used.  Values can be Docker or Source.  Defaults to Source
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {Array} [options.build.env] - an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]
@@ -131,6 +132,7 @@ function undeploy (options = {}) {
   @param {string} [options.outputImageTag] - The tag of the ImageStream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs
   @param {object} [options.build] -
+  @param {string} [options.build.strategy] - flag to change the build strategy used.  Values can be Docker or Source.  Defaults to Source
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {Array} [options.build.env] - an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -99,7 +99,8 @@ async function createOrUpdateBuildConfig (config) {
       incremental: config.build.incremental,
       dockerImage: config.dockerImage,
       buildEnv: config.build.env,
-      webApp: config.webApp
+      webApp: config.webApp,
+      buildStrategy: config.build.strategy
     });
     return config.openshiftRestClient.apis.build.v1.ns(config.namespace.name).buildconfigs.post({ body: newBuildConfig });
   }
@@ -117,7 +118,8 @@ async function createOrUpdateBuildConfig (config) {
       forcePull: config.build.forcePull,
       dockerImage: config.dockerImage,
       buildEnv: config.build.env,
-      webApp: config.webApp
+      webApp: config.webApp,
+      buildStrategy: config.build.strategy
     });
     return config.openshiftRestClient.apis.build.v1.ns(config.namespace.name).buildconfigs.post({ body: newBuildConfig });
   }

--- a/lib/definitions/build-strategy.js
+++ b/lib/definitions/build-strategy.js
@@ -26,22 +26,37 @@ const DEFAULT_DOCKER_TAG = 'latest';
 
 // Default docker image for web-apps
 const DEFAULT_WEB_APP_DOCKER_IMAGE = 'nodeshift/ubi8-s2i-web-app';
+// Adding in the DOCKER build strategy
+// TODO:  Create a basic Dockerfile for the user if there isn't one in their repo
+//        How is this really different from using s2i?
+//        I guess it allows the user to specify a different Node image to use that isn't a s2i image
+//        We could re-use the `dockerImage` and `dockerTag` flags
+//        And default the node image to be the community image and the tag to be lts?
+// TODO:  Add "replace Dockerfile FROM image"
+//        Add custom Dockerfile path
+//        Add custom Docker build arguements
+//        https://docs.openshift.com/container-platform/4.4/builds/build-strategies.html#builds-strategy-docker-build_build-strategies
 
 // https://docs.openshift.com/online/rest_api/openshift_v1.html#v1-buildstrategy
-module.exports = (options = {}) => {
-  // Setting appropriate docker image if web-app flag is set
-  options.dockerImage = options.webApp ? DEFAULT_WEB_APP_DOCKER_IMAGE : options.dockerImage;
+module.exports = (options) => {
+  logger.info(`Using the ${options.buildStrategy} Build Strategy`);
 
-  // Just doing the source strategy
-  const dockerImage = options.dockerImage ? options.dockerImage : DEFAULT_DOCKER_IMAGE;
-  const dockerTag = options.imageTag ? options.imageTag : DEFAULT_DOCKER_TAG;
-  logger.info(`Using s2i image ${dockerImage} with tag ${dockerTag}`);
-  const dockerImageName = `${dockerImage}:${dockerTag}`;
   const env = options.buildEnv || [];
 
-  return {
-    type: 'Source',
-    sourceStrategy: {
+  const strategy = {};
+  strategy.type = options.buildStrategy;
+
+  if (options.buildStrategy === 'Source') {
+    // Setting appropriate docker image if web-app flag is set
+    options.dockerImage = options.webApp ? DEFAULT_WEB_APP_DOCKER_IMAGE : options.dockerImage;
+
+    // Just doing the source strategy
+    const dockerImage = options.dockerImage ? options.dockerImage : DEFAULT_DOCKER_IMAGE;
+    const dockerTag = options.imageTag ? options.imageTag : DEFAULT_DOCKER_TAG;
+    logger.info(`Using s2i image ${dockerImage} with tag ${dockerTag}`);
+    const dockerImageName = `${dockerImage}:${dockerTag}`;
+
+    strategy.sourceStrategy = {
       env: env,
       from: {
         kind: 'DockerImage',
@@ -49,6 +64,14 @@ module.exports = (options = {}) => {
       },
       incremental: options.incremental,
       forcePull: options.forcePull
-    }
-  };
+    };
+  } else {
+    // This is the Docker build strategy
+    strategy.dockerStrategy = {
+      dockerfilePath: 'Dockerfile',
+      env: env
+    };
+  }
+
+  return strategy;
 };

--- a/lib/nodeshift-config.js
+++ b/lib/nodeshift-config.js
@@ -23,6 +23,7 @@ const { OpenshiftClient: openshiftRestClient } = require('openshift-rest-client'
 const fs = require('fs');
 const { promisify } = require('util');
 const readFile = promisify(fs.readFile);
+const _ = require('lodash');
 
 async function setup (options = {}) {
   options.nodeshiftDirectory = '.nodeshift';
@@ -67,6 +68,22 @@ async function setup (options = {}) {
 
   options.outputImageStreamName = options.outputImageStreamName || projectPackage.name;
   options.outputImageStreamTag = options.outputImageStreamTag || 'latest';
+
+  // TODO: do build strategy here
+  // TODO: update buildName based on source or docker strat
+  options.build = options.build || {};
+  // default to the Source(s2i) build strategy
+  // values should be either DOCKER or SOURCE
+  options.build.strategy = options.build.strategy || 'Source';
+  // Make sure the first letter is upperCase
+  options.build.strategy = _.upperFirst(options.build.strategy.toLowerCase());
+
+  // We only support these 2 strategies, so convert to Source if it is an unknown strat.
+  if (options.build.strategy !== 'Docker' && options.build.strategy !== 'Source') {
+    logger.warning(`An unknow build strategy, ${options.build.strategy}, was specified, using the Source strategy instead`);
+    options.build.strategy = 'Source';
+  }
+
   // Return a new object with the config, the rest client and other data.
   return Object.assign({}, config, {
     projectPackage,
@@ -76,7 +93,7 @@ async function setup (options = {}) {
     projectName: projectPackage.name,
     projectVersion: projectPackage.version || '0.0.0',
     // Since we are only doing s2i builds(atm), append the s2i bit to the end
-    buildName: `${projectPackage.name}-s2i`,
+    buildName: `${projectPackage.name}-s2i`, // TODO(lholmquist):  this should probabl change?
     // Load an instance of the Openshift Rest Client, https://www.npmjs.com/package/openshift-rest-client
     openshiftRestClient: restClient
   }, options);

--- a/test/build-config-test.js
+++ b/test/build-config-test.js
@@ -17,6 +17,9 @@ test('create buildConfig not found', (t) => {
     buildName: 'nodejs-s2i-build',
     projectName: 'project-name',
     version: '1.0.0',
+    build: {
+      strategy: 'Source'
+    },
     namespace: {
       name: ''
     },
@@ -73,6 +76,9 @@ test('buildConfig found - no recreate', (t) => {
     buildName: 'nodejs-s2i-build',
     projectName: 'project-name',
     version: '1.0.0',
+    build: {
+      strategy: 'Source'
+    },
     namespace: {
       name: ''
     },
@@ -116,7 +122,8 @@ test('buildConfig found - no recreate', (t) => {
 test('build recreate but is an imagestream', (t) => {
   const config = {
     build: {
-      recreate: 'imagestream'
+      recreate: 'imagestream',
+      strategy: 'Source'
     },
     buildName: 'nodejs-s2i-build',
     projectName: 'project-name',
@@ -223,7 +230,8 @@ test('build recreate true with removing builds', (t) => {
 
   const config = {
     build: {
-      recreate: true
+      recreate: true,
+      strategy: 'Source'
     },
     buildName: 'nodejs-s2i-build',
     projectName: 'project-name',
@@ -313,7 +321,8 @@ test('build recreate true with removing builds with "true"', (t) => {
 
   const config = {
     build: {
-      recreate: 'true'
+      recreate: 'true',
+      strategy: 'Source'
     },
     buildName: 'nodejs-s2i-build',
     projectName: 'project-name',

--- a/test/definitions-tests/build-strategy-test.js
+++ b/test/definitions-tests/build-strategy-test.js
@@ -4,9 +4,10 @@ const test = require('tape');
 const buildStrategy = require('../../lib/definitions/build-strategy');
 
 test('default strategy', (t) => {
-  const result = buildStrategy();
+  const result = buildStrategy({ buildStrategy: 'Source' });
 
   t.equal(result.type, 'Source', 'default is Source type');
+  t.ok(result.sourceStrategy, 'Source strategy object');
   t.equal(result.sourceStrategy.from.name, 'registry.access.redhat.com/ubi8/nodejs-10:latest', 'docker image should be ubi8/nodejs-10:latest image');
   t.equal(result.sourceStrategy.forcePull, undefined, 'no forcePull by default');
 
@@ -14,37 +15,37 @@ test('default strategy', (t) => {
 });
 
 test('strategy with changed dockerTag', (t) => {
-  const result = buildStrategy({ imageTag: '1-20' });
+  const result = buildStrategy({ imageTag: '1-20', buildStrategy: 'Source' });
   t.equal(result.sourceStrategy.from.name, 'registry.access.redhat.com/ubi8/nodejs-10:1-20', 'docker image should be 1-20 ubi8/nodejs-10 image');
   t.end();
 });
 
 test('strategy with changed forcePull', (t) => {
-  const result = buildStrategy({ forcePull: true });
+  const result = buildStrategy({ forcePull: true, buildStrategy: 'Source' });
   t.equal(result.sourceStrategy.forcePull, true, 'forcePull on');
   t.end();
 });
 
 test('strategy with changed forcePull to false', (t) => {
-  const result = buildStrategy({ forcePull: false });
+  const result = buildStrategy({ forcePull: false, buildStrategy: 'Source' });
   t.equal(result.sourceStrategy.forcePull, false, 'forcePull off');
   t.end();
 });
 
 test('strategy with changed incremental', (t) => {
-  const result = buildStrategy({ incremental: true });
+  const result = buildStrategy({ incremental: true, buildStrategy: 'Source' });
   t.equal(result.sourceStrategy.incremental, true, 'incremental on');
   t.end();
 });
 
 test('strategy with changed incremental to false', (t) => {
-  const result = buildStrategy({ incremental: false });
+  const result = buildStrategy({ incremental: false, buildStrategy: 'Source' });
   t.equal(result.sourceStrategy.incremental, false, 'incremental off');
   t.end();
 });
 
 test('strategy with change dockerImage', (t) => {
-  const result = buildStrategy({ dockerImage: 'lholmquist/centos7-s2i-nodejs' });
+  const result = buildStrategy({ dockerImage: 'lholmquist/centos7-s2i-nodejs', buildStrategy: 'Source' });
 
   t.equal(result.sourceStrategy.from.name, 'lholmquist/centos7-s2i-nodejs:latest', 'docker image should be latest lholmquist image');
   t.end();
@@ -58,7 +59,7 @@ test('strategy with env vars', (t) => {
     }
   ];
 
-  const result = buildStrategy({ buildEnv: envs });
+  const result = buildStrategy({ buildEnv: envs, buildStrategy: 'Source' });
 
   t.ok(result.sourceStrategy.env, 'env prop exists');
   t.equal(result.sourceStrategy.env[0].name, 'NODE_ENV', 'has the name value');
@@ -67,22 +68,30 @@ test('strategy with env vars', (t) => {
 });
 
 test('defaults to using latest ubi8/nodejs-10 s2i builder image', t => {
-  const result = buildStrategy();
+  const result = buildStrategy({ buildStrategy: 'Source' });
 
   t.equals(result.sourceStrategy.from.name, 'registry.access.redhat.com/ubi8/nodejs-10:latest');
   t.end();
 });
 
 test('accepts a node version using imageTag option', t => {
-  const result = buildStrategy({ imageTag: '1-20' });
+  const result = buildStrategy({ imageTag: '1-20', buildStrategy: 'Source' });
 
   t.equals(result.sourceStrategy.from.name, 'registry.access.redhat.com/ubi8/nodejs-10:1-20');
   t.end();
 });
 
 test('strategy with web-app option enabled', (t) => {
-  const result = buildStrategy({ webApp: true });
+  const result = buildStrategy({ webApp: true, buildStrategy: 'Source' });
 
   t.equal(result.sourceStrategy.from.name, 'nodeshift/ubi8-s2i-web-app:latest', 'docker image should be latest web-app image');
+  t.end();
+});
+
+test('Docker strategy', (t) => {
+  const result = buildStrategy({ buildStrategy: 'Docker' });
+
+  t.equal(result.type, 'Docker', 'use Docker type');
+  t.ok(result.dockerStrategy, 'correct strategy object');
   t.end();
 });

--- a/test/nodeshift-config-test.js
+++ b/test/nodeshift-config-test.js
@@ -421,3 +421,36 @@ test('nodeshift-config options - change outputImageStreamTag and outputImageStre
     t.end();
   });
 });
+
+test('nodeshift-config options - not recognized build strategy', (t) => {
+  const nodeshiftConfig = proxyquire('../lib/nodeshift-config', {
+    'openshift-rest-client': {
+      OpenshiftClient: () => {
+        return Promise.resolve({
+          kubeconfig: {
+            getCurrentContext: () => {
+              return 'nodey/ip/other';
+            },
+            getCurrentCluster: () => {
+              return { server: 'http://mock-cluster' };
+            },
+            getContexts: () => {
+              return [{ name: 'nodey/ip/other', namespace: 'test-namespace' }];
+            }
+          }
+        });
+      }
+    }
+  });
+
+  const options = {
+    build: {
+      strategy: 'CustomStrat'
+    }
+  };
+
+  nodeshiftConfig(options).then((config) => {
+    t.equal(config.build.strategy, 'Source', 'should be Source');
+    t.end();
+  });
+});


### PR DESCRIPTION
* This adds a new flag `build.strategy` which takes the values Docker or Source.  default to Source.

* Source will build with an s2i image, while Docker will use the Dockerfile from the application to build.

To use the Docker strat, you would do `npx nodeshift --build.strategy=Docker`



For testing this out,  i've been using CRC,  and this sample dockerized node app, https://github.com/nodeshift-starters/basic-node-app-dockerized



