### PR TITLE
chore: update openshift-rest-client to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7595,9 +7595,9 @@
       }
     },
     "openshift-rest-client": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/openshift-rest-client/-/openshift-rest-client-4.1.0.tgz",
-      "integrity": "sha512-jWfrjQD1CRytRoElkcrQZDMw7+5n/JRYzUwuk5ATE69lWDXePu0tkVaZlxgxRDxkJhbYmbso1V5L6JlgFLt8tQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/openshift-rest-client/-/openshift-rest-client-4.1.1.tgz",
+      "integrity": "sha512-SSr71ZtcugdD9S73av49jeGs8ZxhcIOP125vVlvcKQ/HlVEbrF61xr916SYf0r1rjQAgz2uWVbppheCpwmZXfA==",
       "requires": {
         "kubernetes-client": "8.3.6",
         "request": "~2.88.2"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "js-yaml": "~3.13.1",
     "lodash": "^4.17.4",
     "mkdirp": "^1.0.3",
-    "openshift-rest-client": "4.1.0",
+    "openshift-rest-client": "~4.1.1",
     "tar": "~6.0.2",
     "yargs": "^15.2.0"
   },


### PR DESCRIPTION
* This will fix an issue where you couldn't pass a nomral javascript kubernetes config object