### PR TITLE
Adding .gitignore support in project-archiver

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -22,10 +22,13 @@ const jsyaml = require('js-yaml');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const { promisify } = require('util');
+const minimatch = require('minimatch');
+const parse = require('parse-gitignore');
 
 const rmrf = require('./utils/rmrf');
 
 const readdir = promisify(fs.readdir);
+const readfile = promisify(fs.readFile);
 
 // Take yaml as a string that has already been loaded from a file or something.
 function yamlToJson (yamlToParse) {
@@ -90,6 +93,19 @@ async function awaitRequest (promise) {
   return result;
 }
 
+async function parseIgnoreFile (path) {
+  try {
+    const file = await readfile(path);
+    return parse(file);
+  } catch (e) {
+    return [];
+  }
+}
+
+function matchRule (filename, rule) {
+  return minimatch(filename, rule);
+}
+
 module.exports = {
   yamlToJson: yamlToJson,
   normalizeFileList: normalizeFileList,
@@ -98,5 +114,7 @@ module.exports = {
   listFiles: listFiles,
   parseMultiOption: parseMultiOption,
   wait,
-  awaitRequest
+  awaitRequest,
+  parseIgnoreFile,
+  matchRule
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -94,12 +94,11 @@ async function awaitRequest (promise) {
 }
 
 async function parseIgnoreFile (path) {
-  try {
-    const file = await readfile(path);
-    return parse(file);
-  } catch (e) {
+  if (!fs.existsSync(path)) {
     return [];
   }
+  const file = await readfile(path);
+  return parse(file);
 }
 
 function matchRule (filename, rule) {

--- a/lib/project-archiver.js
+++ b/lib/project-archiver.js
@@ -42,16 +42,32 @@ async function createArchive (config) {
     logger.warning('a file property was not found in your package.json, archiving the current directory.');
     // Get the list of files and directories
     const fileList = await helpers.listFiles(config.projectLocation);
+    // Default file exclusion rules
+    const exclusionRules = [
+      'node_modules',
+      '.git',
+      'tmp'
+    ];
+    // Parse ignore files
+    const gitignoreRules = await helpers.parseIgnoreFile(`${config.projectLocation}/.gitignore`);
+    exclusionRules.push.apply(exclusionRules, gitignoreRules);
     // Push those into the includedFiles
     const filteredOut = fileList.filter((file) => {
-      // exclude the node_modules and .git directories and tmp
-      if (file === 'node_modules' || file === '.git' || file === 'tmp') {
-        return false;
+      let include = true;
+      for (const rule of exclusionRules) {
+        if (rule[0] === '!') continue; // Don't check rule negations yet
+        if (helpers.matchRule(file, rule)) {
+          include = false;
+          break;
+        }
       }
-
-      return true;
+      if (!include) {
+        // Search for rule negation
+        const negationRule = exclusionRules.indexOf(`!${file}`);
+        if (negationRule !== -1) return true;
+      }
+      return include;
     });
-
     includedFiles.push.apply(includedFiles, filteredOut);
   }
   logger.info(`creating archive of ${includedFiles.join(', ')}`);

--- a/lib/project-archiver.js
+++ b/lib/project-archiver.js
@@ -48,9 +48,12 @@ async function createArchive (config) {
       '.git',
       'tmp'
     ];
-    // Parse ignore files
+    // Parse gitignore file if any
     const gitignoreRules = await helpers.parseIgnoreFile(`${config.projectLocation}/.gitignore`);
     exclusionRules.push.apply(exclusionRules, gitignoreRules);
+    // Parse dockerignore file if any
+    const dockerignoreRules = await helpers.parseIgnoreFile(`${config.projectLocation}/.dockerignore`);
+    exclusionRules.push.apply(exclusionRules, dockerignoreRules);
     // Push those into the includedFiles
     const filteredOut = fileList.filter((file) => {
       let include = true;

--- a/lib/project-archiver.js
+++ b/lib/project-archiver.js
@@ -18,6 +18,7 @@
 
 'use strict';
 
+const _ = require('lodash');
 const tar = require('tar');
 const logger = require('./common-log')();
 const helpers = require('./helpers');
@@ -49,11 +50,18 @@ async function createArchive (config) {
       'tmp'
     ];
     // Parse gitignore file if any
-    const gitignoreRules = await helpers.parseIgnoreFile(`${config.projectLocation}/.gitignore`);
-    exclusionRules.push.apply(exclusionRules, gitignoreRules);
+    const gitignoreRules = await helpers.parseIgnoreFile(
+      `${config.projectLocation}/.gitignore`
+    );
     // Parse dockerignore file if any
-    const dockerignoreRules = await helpers.parseIgnoreFile(`${config.projectLocation}/.dockerignore`);
-    exclusionRules.push.apply(exclusionRules, dockerignoreRules);
+    const dockerignoreRules = await helpers.parseIgnoreFile(
+      `${config.projectLocation}/.dockerignore`
+    );
+    // Remove duplicate exclusion rules
+    exclusionRules.push.apply(
+      exclusionRules,
+      _.union(gitignoreRules, dockerignoreRules)
+    );
     // Push those into the includedFiles
     const filteredOut = fileList.filter((file) => {
       let include = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7799,6 +7799,11 @@
       "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
       "dev": true
     },
+    "parse-gitignore": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-1.0.1.tgz",
+      "integrity": "sha512-UGyowyjtx26n65kdAMWhm6/3uy5uSrpcuH7tt+QEVudiBoVS+eqHxD5kbi9oWVRwj7sCzXqwuM+rUGw7earl6A=="
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,10 @@
     "git-repo-info": "^2.0.0",
     "js-yaml": "~3.14.0",
     "lodash": "^4.17.4",
+    "minimatch": "^3.0.4",
     "mkdirp": "^1.0.3",
     "openshift-rest-client": "~4.1.1",
+    "parse-gitignore": "^1.0.1",
     "tar": "~6.0.2",
     "yargs": "^15.2.0"
   },

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -169,14 +169,33 @@ test('test yamlToJson function', (t) => {
   t.end();
 });
 
-test('test parseIgnoreFile function - return empty array if error', (t) => {
+test('test parseIgnoreFile function - return empty array if file does not exists', (t) => {
   const helpers = proxyquire('../lib/helpers', {
     fs: {
-      readFile: (path, cb) => cb(new Error('Error: error opening file'))
+      existsSync: (path) => false
     }
   });
   helpers.parseIgnoreFile('.gitignore').then(result => {
     t.deepEquals([], result, 'should return empty array');
     t.end();
   });
+});
+
+test('test parseIgnoreFile function - fail on error', (t) => {
+  const helpers = proxyquire('../lib/helpers', {
+    fs: {
+      existsSync: (path) => true,
+      readFile: (path, cb) => cb(new Error('Error: file can not be opened'))
+    }
+  });
+  helpers
+    .parseIgnoreFile('.gitignore')
+    .then(() => {
+      t.fail('should not pass');
+      t.end();
+    })
+    .catch(() => {
+      t.pass('should pass');
+      t.end();
+    });
 });

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -168,3 +168,15 @@ test('test yamlToJson function', (t) => {
   t.deepEquals({}, result, 'should return json object');
   t.end();
 });
+
+test('test parseIgnoreFile function - return empty array if error', (t) => {
+  const helpers = proxyquire('../lib/helpers', {
+    fs: {
+      readFile: (path, cb) => cb(new Error('Error: error opening file'))
+    }
+  });
+  helpers.parseIgnoreFile('.gitignore').then(result => {
+    t.deepEquals([], result, 'should return empty array');
+    t.end();
+  });
+});


### PR DESCRIPTION
This PR adds .gitignore file support in nodeshift's project archiver. #460 

Two new NPM packages have been used:

- **parse-gitignore**: transforms .gitignore's contents into a javascript array.
- **minimatch**: performs some filename checks according to given rules (same module **NPM** uses internally for the same job)

> Maybe we can work out some custom implementation for the .gitignore parser if we want to reduce the amount of 3rd party modules that we use.

**.dockerignore** support should be 2-3 extra lines of code since the core implementation is done.

@lholmquist @helio-frota I'm just pinging you here cause I can't add any reviewers for this PR

If you guys think everything is OK I'll continue with the .dockerignore support and tests.