### PR TITLE
feat(knative): Each deploy should create a new revision.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -105,6 +105,11 @@ function matchRule (filename, rule) {
   return minimatch(filename, rule);
 }
 
+function generateUUID () {
+  // Quick and dirty solution, since we are only using this for generating an appID
+  return Math.random().toString(26).slice(2);
+}
+
 module.exports = {
   yamlToJson: yamlToJson,
   normalizeFileList: normalizeFileList,
@@ -115,5 +120,6 @@ module.exports = {
   wait,
   awaitRequest,
   parseIgnoreFile,
-  matchRule
+  matchRule,
+  generateUUID
 };

--- a/lib/knative-serving-service.js
+++ b/lib/knative-serving-service.js
@@ -19,7 +19,7 @@
 'use strict';
 
 const log = require('./common-log')();
-const { awaitRequest } = require('./helpers');
+const { awaitRequest, generateUUID } = require('./helpers');
 
 module.exports = async function getKnativeServingServices (config, resource) {
   const knativeService = await awaitRequest(config.openshiftRestClient.apis['serving.knative.dev'].v1.ns(config.namespace.name).service(resource.metadata.name).get());
@@ -30,6 +30,11 @@ module.exports = async function getKnativeServingServices (config, resource) {
     return config.openshiftRestClient.apis['serving.knative.dev'].v1.ns(config.namespace.name).service.post({ body: resource });
   }
 
-  log.info(`using existing service ${knativeService.body.metadata.name}`);
-  return knativeService;
+  // Trying not to mutate returned objects
+  const updateKnativeService = { ...knativeService.body };
+
+  // Update appId metadata label in the template section to create a new revision
+  updateKnativeService.spec.template.metadata.labels.appId = generateUUID();
+  log.info(`Updating service ${resource.metadata.name}`);
+  return config.openshiftRestClient.apis['serving.knative.dev'].v1.ns(config.namespace.name).service(resource.metadata.name).put({ body: updateKnativeService });
 };

--- a/lib/resource-enrichers/knative-service-enricher.js
+++ b/lib/resource-enrichers/knative-service-enricher.js
@@ -20,6 +20,7 @@
 
 const _ = require('lodash');
 const objectMetadata = require('../definitions/object-metadata');
+const { generateUUID } = require('../helpers');
 
 const baseServiceConfig = {
   apiVersion: 'serving.knative.dev/v1',
@@ -39,6 +40,12 @@ function defaultService (config) {
 
   // TODO(lholmquist): Should this also take into account docker images that are not in the openshift registry
   serviceConfig.spec.template = {
+    metadata: {
+      labels: {
+        name: config.projectName,
+        appId: generateUUID() // This is to trigger a new revision on each push
+      }
+    },
     spec: {
       containers: [
         {

--- a/test/knative-serving-service-test.js
+++ b/test/knative-serving-service-test.js
@@ -15,6 +15,27 @@ test('test knative serving service, already created', (t) => {
     }
   };
 
+  const returnedResource = {
+    code: 200,
+    body:
+    {
+      kind: 'Service',
+      apiVersion: 'serving.knative.dev/v1',
+      metadata: {
+        name: 'service'
+      },
+      spec: {
+        template: {
+          metadata: {
+            labels: {
+              appId: 'thing'
+            }
+          }
+        }
+      }
+    }
+  };
+
   const config = {
     projectName: 'test-project',
     namespace: {
@@ -32,8 +53,11 @@ test('test knative serving service, already created', (t) => {
                     t.fail('name argument does not match the resource.metadata.name');
                   }
                   return {
+                    put: () => {
+                      return Promise.resolve(returnedResource);
+                    },
                     get: () => {
-                      return Promise.resolve({ code: 200, body: { kind: 'Service', apiVersion: 'serving.knative.dev/v1', metadata: { name: 'service' } } });
+                      return Promise.resolve(returnedResource);
                     }
                   };
                 }
@@ -53,7 +77,7 @@ test('test knative serving service, already created', (t) => {
   t.equal(p instanceof Promise, true, 'should return a Promise');
 });
 
-test('test routes, not created', (t) => {
+test('test knative Serving Service, not created', (t) => {
   const knServices = require('../lib/knative-serving-service');
   const resource = {
     apiVersion: 'serving.knative.dev/v1',


### PR DESCRIPTION
* This adds in a generated appId label to the service template metadata to create a new revision on each deployment

fixes #466 


some tests still need to be added