### PR TITLE
feat: Nodeshift should be able to use a Deployment type

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Flag to pass build config environment variables as NAME=Value.  Can be used mult
 Flag to change the build strategy used.  Values can be Docker or Source.  Defaults to Source
 
 #### useDeployment
-Flag to deploy the application using a Deployment instead of a DeploymentConfig
+Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
 
 #### knative
 EXPERIMENTAL. Flag to deploy an application as a Knative Serving Service.  Defaults to false

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To set that using nodeshift, use the `-d` option with a KEY=VALUE, like this:
 
 A user can specify exactly what files would like nodeshift to include to the archive it will generate by using the files property in package.json.
 
-If a user does not use the files property in the package.json to filter what files they would like to include, then nodeshift by default will include everything except the **node_modules**, **.git** and **tmp** directories. 
+If a user does not use the files property in the package.json to filter what files they would like to include, then nodeshift by default will include everything except the **node_modules**, **.git** and **tmp** directories.
 
 Nodeshift will also look for additional exclusion rules at a .gitignore file if there is one. Same thing with a .dockerignore file.
 
@@ -207,6 +207,9 @@ Flag to pass build config environment variables as NAME=Value.  Can be used mult
 #### build.strategy
 Flag to change the build strategy used.  Values can be Docker or Source.  Defaults to Source
 
+#### useDeployment
+Flag to deploy the application using a Deployment instead of a DeploymentConfig
+
 #### knative
 EXPERIMENTAL. Flag to deploy an application as a Knative Serving Service.  Defaults to false
 Since this feature is experimental,  it is subject to change without a Major version release until it is fully stable.
@@ -268,6 +271,9 @@ Shows the below help
             --metadata.out           determines what should be done with the response
                                     metadata from OpenShift
                     [string] [choices: "stdout", "ignore", "<filename>"] [default: "ignore"]
+            --useDeployment          flag to deploy the application using a Deployment
+                           instead of a DeploymentConfig
+                               [boolean] [choices: true, false] [default: false]
             --knative                EXPERIMENTAL. flag to deploy an application
                            as a Knative Serving Service
                                [boolean] [choices: true, false] [default: false]

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -168,6 +168,8 @@ function commandHandler (argv) {
 function createOptions (argv) {
   const options = {};
 
+  options.useDeployment = argv.useDeployment;
+
   options.knative = argv.knative === true || argv.knative === 'true';
 
   options.projectLocation = argv.projectLocation;

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -130,6 +130,12 @@ yargs
     type: 'string',
     default: 'ignore'
   })
+  .options('useDeployment', {
+    describe: 'flag to deploy the application using a Deployment instead of a DeploymentConfig',
+    choices: [true, false],
+    type: 'boolean',
+    default: false
+  })
   .options('knative', {
     describe: 'EXPERIMENTAL. flag to deploy an application as a Knative Serving Service',
     choices: [true, false],

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const cli = require('./bin/cli');
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {Array} [options.build.env] - an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
+  @param {boolean} [options.useDeployment] - Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
   @param {boolean} [options.knative] - EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
   @returns {Promise<object>} - Returns a JSON Object
 */
@@ -56,6 +57,7 @@ function deploy (options = {}) {
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
+  @param {boolean} [options.useDeployment] - Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
   @param {boolean} [options.knative] - EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
   @returns {Promise<object>} - Returns a JSON Object
 */
@@ -85,6 +87,7 @@ function resource (options = {}) {
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
+  @param {boolean} [options.useDeployment] - Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
   @param {boolean} [options.knative] - EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
   @returns {Promise<object>} - Returns a JSON Object
 */
@@ -114,6 +117,7 @@ function applyResource (options = {}) {
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
+  @param {boolean} [options.useDeployment] - Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
   @param {boolean} [options.knative] - EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
   @returns {Promise<object>} - Returns a JSON Object
 */

--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -1,24 +1,63 @@
 'use strict';
 
 const logger = require('./common-log')();
+const { awaitRequest } = require('./helpers');
 
-async function applyDeployment (config, resourceToDeploy) {
+async function applyDeployment (config, deploymentResource) {
   // Check to see if there is a Deployment first
   // If not then create
   // If So then replace
 
   try {
-    const create = await config.openshiftRestClient.apis.apps.v1.namespaces(config.namespace.name).deployments.post({ body: resourceToDeploy });
+    const create = await config.openshiftRestClient.apis.apps.v1.namespaces(config.namespace.name).deployments.post({ body: deploymentResource });
     logger.trace('Deployment Applied');
     return create;
   } catch (err) {
     if (err.code !== 409) throw err;
-    const replace = await config.openshiftRestClient.apis.apps.v1.namespaces(config.namespace.name).deployments(config.projectName).put({ body: resourceToDeploy });
+    const replace = await config.openshiftRestClient.apis.apps.v1.namespaces(config.namespace.name).deployments(config.projectName).put({ body: deploymentResource });
     logger.trace('Deployment Updated');
     return replace;
   }
 }
 
+async function removeDeployment (config, deploymentResource) {
+  const removeOptionsDeployment = {
+    body: {
+      orphanDependents: true,
+      gracePeriodSeconds: undefined
+    }
+  };
+
+  const response = {
+    replicaSets: []
+  };
+
+  logger.info(`Deleting Deployment ${deploymentResource.metadata.name}`);
+  response.deployment = await awaitRequest(config.openshiftRestClient.apis.apps.v1.ns(config.namespace.name).deployments(deploymentResource.metadata.name).delete({ body: removeOptionsDeployment }));
+
+  // Since this is a Deployment, get the replica sets and delete them
+  const rsList = await config.openshiftRestClient.apis.apps.v1.ns(config.namespace.name).replicasets.get({ qs: { labelSelector: `app=${config.projectName}` } });
+
+  const removeOptionsReplicaSets = {
+    body: {
+      orphanDependents: false,
+      gracePeriodSeconds: undefined
+    }
+  };
+
+  // Delete the replicasets
+
+  for (const items of rsList.body.items) {
+    logger.info(`Deleting replica set ${items.metadata.name}`);
+    response.replicaSets.push(
+      await awaitRequest(config.openshiftRestClient.apis.apps.v1.ns(config.namespace.name).replicasets(items.metadata.name).delete({ body: removeOptionsReplicaSets }))
+    );
+  }
+
+  return response;
+}
+
 module.exports = {
-  applyDeployment
+  applyDeployment,
+  removeDeployment
 };

--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const logger = require('./common-log')();
+
+async function applyDeployment (config, resourceToDeploy) {
+  // Check to see if there is a Deployment first
+  // If not then create
+  // If So then replace
+
+  try {
+    const create = await config.openshiftRestClient.apis.apps.v1.namespaces(config.namespace.name).deployments.post({ body: resourceToDeploy });
+    logger.trace('Deployment Applied');
+    return create;
+  } catch (err) {
+    if (err.code !== 409) throw err;
+    const replace = await config.openshiftRestClient.apis.apps.v1.namespaces(config.namespace.name).deployments(config.projectName).put({ body: resourceToDeploy });
+    logger.trace('Deployment Updated');
+    return replace;
+  }
+}
+
+module.exports = {
+  applyDeployment
+};

--- a/lib/enrich-resources.js
+++ b/lib/enrich-resources.js
@@ -21,6 +21,7 @@
 const loadEnrichers = require('./load-enrichers');
 const defaultEnrichers = require('./resource-enrichers/default-enrichers.json');
 const knativeEnrichers = require('./resource-enrichers/knative-enrichers.json');
+const deploymentEnrichers = require('./resource-enrichers/deployment-enrichers.json');
 
 // TODO: Add Knative Serving Enrichers to run instead?
 // Split the defaults to be "normal" and "knative"?
@@ -32,7 +33,7 @@ module.exports = async (config, resourceList) => {
   // Loop through those and then enrich the items from the resourceList
   let enrichedList = resourceList;
   // the defaultEnrichers list will have the correct order
-  for (const enricher of (config.knative ? knativeEnrichers : defaultEnrichers)) {
+  for (const enricher of (config.knative ? knativeEnrichers : config.useDeployment ? deploymentEnrichers : defaultEnrichers)) {
     const fn = loadedEnrichers[enricher];
     if (typeof fn === 'function') {
       enrichedList = await fn(config, enrichedList);

--- a/lib/goals/apply-resources.js
+++ b/lib/goals/apply-resources.js
@@ -25,6 +25,7 @@ const deploymentConfig = require('../deployment-config').deploy;
 const secrets = require('../secrets');
 const ingress = require('../ingress');
 const configMap = require('../config-map');
+const { applyDeployment } = require('../deployment.js');
 
 module.exports = (config, resourceList) => {
   const mappedResources = resourceList.map((r) => {
@@ -38,6 +39,8 @@ module.exports = (config, resourceList) => {
         return routes(config, r);
       case 'DeploymentConfig':
         return deploymentConfig(config, r);
+      case 'Deployment':
+        return applyDeployment(config, r);
       case 'Secret':
         return secrets(config, r);
       case 'Ingress':

--- a/lib/goals/undeploy.js
+++ b/lib/goals/undeploy.js
@@ -32,6 +32,7 @@ const logger = require('../common-log')();
 const readFile = promisify(fs.readFile);
 
 const { undeploy } = require('../deployment-config');
+const { removeDeployment } = require('../deployment');
 const { removeBuildsAndBuildConfig } = require('../build-config');
 const { removeImageStream } = require('../image-stream');
 const { awaitRequest } = require('../helpers.js');
@@ -64,6 +65,9 @@ module.exports = async function (config) {
         } else {
           response.service = await awaitRequest(config.openshiftRestClient.api.v1.ns(config.namespace.name).service(item.metadata.name).delete({ body: removeOptions }));
         }
+        break;
+      case 'Deployment':
+        response.deployment = await removeDeployment(config, item);
         break;
       case 'DeploymentConfig':
         response.deploymentConfig = await undeploy(config, item);

--- a/lib/resource-enrichers/deployment-enricher.js
+++ b/lib/resource-enrichers/deployment-enricher.js
@@ -10,6 +10,7 @@ const baseDeployment = {
 };
 
 function defaultDeployment (config) {
+  /* eslint no-useless-escape: "off" */
   const trigger = [{ from: { kind: 'ImageStreamTag', name: `${config.outputImageStreamName}:latest`, namespace: config.namespace.name }, fieldPath: `spec.template.spec.containers[?(@.name==\"${config.projectName}\")].image` }];
 
   const metaAnnotations = {
@@ -44,9 +45,6 @@ function defaultDeployment (config) {
       }
     }
   };
-
-  // image.openshift.io/triggers: >-
-  //     [{'from":{"kind":"ImageStreamTag","name":"fun-with-deployments:latest","namespace":"deployments-testsing"},"fieldPath":"spec.template.spec.containers[?(@.name==\"fun-with-deployments-part2\")].image"}]
 
   return { ...baseDeployment, spec: spec, metadata: { name: config.projectName, annotations: metaAnnotations } };
 }

--- a/lib/resource-enrichers/deployment-enricher.js
+++ b/lib/resource-enrichers/deployment-enricher.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const _ = require('lodash');
+
+const baseDeployment = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {},
+  spec: {}
+};
+
+function defaultDeployment (config) {
+  const trigger = [{ from: { kind: 'ImageStreamTag', name: `${config.outputImageStreamName}:latest`, namespace: config.namespace.name }, fieldPath: `spec.template.spec.containers[?(@.name=='${config.projectName}')].image` }];
+
+  const metaAnnotations = {
+    'image.openshift.io/triggers': JSON.stringify(trigger)
+  };
+  const spec = {
+    selector: {
+      matchLabels: {
+        app: config.projectName
+      }
+    },
+    template: {
+      metadata: {
+        labels: {
+          app: config.projectName,
+          deploymentconfig: config.projectName
+        }
+      },
+      spec: {
+        containers: [
+          {
+            name: config.projectName,
+            image: `image-registry.openshift-image-registry.svc:5000/${config.namespace.name}/${config.outputImageStreamName}`,
+            imagePullPolicy: 'IfNotPresent',
+            ports: [
+              {
+                containerPort: config.port
+              }
+            ]
+          }
+        ]
+      }
+    }
+  };
+
+  // image.openshift.io/triggers: >-
+  //     [{'from":{"kind":"ImageStreamTag","name":"fun-with-deployments:latest","namespace":"deployments-testsing"},"fieldPath":"spec.template.spec.containers[?(@.name==\"fun-with-deployments-part2\")].image"}]
+
+  return { ...baseDeployment, spec: spec, metadata: { name: config.projectName, annotations: metaAnnotations } };
+}
+
+function createDeploymentResource (config, resourceList) {
+  // First check to see if we have a Deployment
+  if (_.filter(resourceList, { kind: 'Deployment' }).length < 1) {
+    // create the default deployment config and add in to the resource list
+    resourceList.push(defaultDeployment(config));
+    return resourceList;
+  }
+
+  // return resourceList.map((resource) => {
+  //   if (resource.kind !== 'Deployment' && resource.kind !== 'DeploymentConfig') {
+  //     return resource;
+  //   }
+
+  //   // This first "converts" the Deployment into a DeploymentConfig. probably will make sense more when we are just straight up kube
+  //   const deploymentConfig = _.merge({}, resource, { kind: 'DeploymentConfig' });
+
+  //   // Merge the default Service Config with the current resource
+  //   return _.merge({}, defaultDeploymentConfig(config), deploymentConfig);
+  // });
+}
+
+module.exports = {
+  enrich: createDeploymentResource,
+  name: 'deployment'
+};
+
+// apiVersion: apps/v1
+// kind: Deployment
+// metadata:
+//   name: hello-openshift
+// spec:
+//   replicas: 1
+//   selector:
+//     matchLabels:
+//       app: hello-openshift
+//   template:
+//     metadata:
+//       labels:
+//         app: hello-openshift
+//     spec:
+//       containers:
+//       - name: hello-openshift
+//         image: openshift/hello-openshift:latest
+//         ports:
+//         - containerPort: 80

--- a/lib/resource-enrichers/deployment-enricher.js
+++ b/lib/resource-enrichers/deployment-enricher.js
@@ -57,17 +57,14 @@ function createDeploymentResource (config, resourceList) {
     return resourceList;
   }
 
-  // return resourceList.map((resource) => {
-  //   if (resource.kind !== 'Deployment' && resource.kind !== 'DeploymentConfig') {
-  //     return resource;
-  //   }
+  return resourceList.map((resource) => {
+    if (resource.kind !== 'Deployment') {
+      return resource;
+    }
 
-  //   // This first "converts" the Deployment into a DeploymentConfig. probably will make sense more when we are just straight up kube
-  //   const deploymentConfig = _.merge({}, resource, { kind: 'DeploymentConfig' });
-
-  //   // Merge the default Service Config with the current resource
-  //   return _.merge({}, defaultDeploymentConfig(config), deploymentConfig);
-  // });
+    // Merge the default Deployment with the current resource
+    return _.merge({}, defaultDeployment(config), resource);
+  });
 }
 
 module.exports = {

--- a/lib/resource-enrichers/deployment-enricher.js
+++ b/lib/resource-enrichers/deployment-enricher.js
@@ -10,7 +10,7 @@ const baseDeployment = {
 };
 
 function defaultDeployment (config) {
-  const trigger = [{ from: { kind: 'ImageStreamTag', name: `${config.outputImageStreamName}:latest`, namespace: config.namespace.name }, fieldPath: `spec.template.spec.containers[?(@.name=='${config.projectName}')].image` }];
+  const trigger = [{ from: { kind: 'ImageStreamTag', name: `${config.outputImageStreamName}:latest`, namespace: config.namespace.name }, fieldPath: `spec.template.spec.containers[?(@.name==\"${config.projectName}\")].image` }];
 
   const metaAnnotations = {
     'image.openshift.io/triggers': JSON.stringify(trigger)

--- a/lib/resource-enrichers/deployment-enrichers.json
+++ b/lib/resource-enrichers/deployment-enrichers.json
@@ -1,3 +1,3 @@
 [
-  "deployment", "service", "route", "labels", "git-info", "runtime-label"
+  "deployment", "service", "route", "labels", "git-info", "health-check", "runtime-label"
 ]

--- a/lib/resource-enrichers/deployment-enrichers.json
+++ b/lib/resource-enrichers/deployment-enrichers.json
@@ -1,0 +1,3 @@
+[
+  "deployment", "service", "route", "labels", "git-info", "runtime-label"
+]

--- a/test/deployment-test.js
+++ b/test/deployment-test.js
@@ -1,0 +1,238 @@
+'use strict';
+
+const test = require('tape');
+const deployment = require('../lib/deployment');
+
+test('deployment', (t) => {
+  t.ok(deployment.applyDeployment, 'should have an applyDeployment method');
+  t.ok(deployment.removeDeployment, 'should have a removeDeployment method');
+  t.equal(typeof deployment.applyDeployment, 'function', 'should be a function');
+  t.equal(typeof deployment.removeDeployment, 'function', 'should be a function');
+
+  t.end();
+});
+
+test('deploy - not created yet', (t) => {
+  const deploymentResource = {
+    kind: 'Deployment',
+    metadata: {
+      name: 'deployment'
+    }
+  };
+
+  const config = {
+    projectName: 'my Project',
+    namespace: {
+      name: ''
+    },
+    openshiftRestClient: {
+      apis: {
+        apps: {
+          v1: {
+            namespaces: (namespace) => {
+              return {
+                deployments: {
+                  post: (resource) => {
+                    t.equal(resource.body, deploymentResource, 'resource should be the same as passed in');
+                    Promise.resolve({ code: 201, body: resource });
+                  }
+                }
+              };
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const p = deployment.applyDeployment(config, deploymentResource);
+  t.equal(p instanceof Promise, true, 'should return a promise');
+
+  p.then(() => {
+    t.pass();
+    t.end();
+  });
+});
+
+test('deploy - created already', (t) => {
+  const deploymentResource = {
+    kind: 'Deployment',
+    metadata: {
+      name: 'deployment'
+    }
+  };
+
+  let call = 0;
+
+  const config = {
+    projectName: 'my Project',
+    namespace: {
+      name: ''
+    },
+    openshiftRestClient: {
+      apis: {
+        apps: {
+          v1: {
+            namespaces: (namespace) => {
+              if (call === 0) {
+                call++;
+                return {
+                  deployments: {
+                    post: (resource) => {
+                      t.equal(resource.body, deploymentResource, 'resource should be the same as passed in');
+                      /* eslint prefer-promise-reject-errors: "off" */
+                      return Promise.reject({ code: 409 });
+                    }
+                  }
+                };
+              } else {
+                return {
+                  deployments: (deploymentName) => {
+                    return {
+                      put: (resource) => {
+                        Promise.resolve({ code: 201 });
+                      }
+                    };
+                  }
+                };
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const p = deployment.applyDeployment(config, deploymentResource);
+  t.equal(p instanceof Promise, true, 'should return a promise');
+
+  p.then(() => {
+    t.pass();
+    t.end();
+  });
+});
+
+test('deploy - created already - but error', (t) => {
+  const deploymentResource = {
+    kind: 'Deployment',
+    metadata: {
+      name: 'deployment'
+    }
+  };
+
+  let call = 0;
+
+  const config = {
+    projectName: 'my Project',
+    namespace: {
+      name: ''
+    },
+    openshiftRestClient: {
+      apis: {
+        apps: {
+          v1: {
+            namespaces: (namespace) => {
+              return {
+                deployments: {
+                  post: (resource) => {
+                    t.equal(resource.body, deploymentResource, 'resource should be the same as passed in');
+                    /* eslint prefer-promise-reject-errors: "off" */
+                    return Promise.reject({ code: 401 });
+                  }
+                }
+              };
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const p = deployment.applyDeployment(config, deploymentResource);
+  t.equal(p instanceof Promise, true, 'should return a promise');
+
+  p.then(() => {
+    t.fail();
+  }).catch(() => {
+    t.pass();
+    t.end();
+  });
+});
+
+test('undeploy', (t) => {
+  const deploymentResource = {
+    kind: 'Deployment',
+    metadata: {
+      name: 'deployment'
+    }
+  };
+
+  const replicasetList = {
+    items: [{
+      metadata: {
+        name: 'replicant'
+      }
+    }]
+  };
+
+  let call = 0;
+
+  const config = {
+    projectName: 'my Project',
+    namespace: {
+      name: ''
+    },
+    openshiftRestClient: {
+      apis: {
+        apps: {
+          v1: {
+            ns: (namespace) => {
+              let replicaSet;
+              if (call === 1) {
+                // do the delete
+                replicaSet = (projectName) => {
+                  t.equal(projectName, replicasetList.items[0].metadata.name, 'name should be equal');
+                  return {
+                    delete: (removal) => {
+                      t.pass();
+                      t.equal(removal.body.body.orphanDependents, false, 'this options should be false');
+                      return Promise.resolve({ code: 204 });
+                    }
+                  };
+                };
+              } else {
+                replicaSet = {
+                  get: (options) => {
+                    call++;
+                    t.equal(options.qs.labelSelector, `app=${config.projectName}`, 'should be equal');
+                    return Promise.resolve({ code: 200, body: replicasetList });
+                  }
+                };
+              }
+              return {
+                replicasets: replicaSet,
+                deployments: (deploymentName) => {
+                  t.equal(deploymentName, deploymentResource.metadata.name, 'names should be equal');
+                  return {
+                    delete: (removeThisResource) => {
+                      t.equal(removeThisResource.body.body.orphanDependents, true, 'this options should be true');
+                      return Promise.resolve({ code: 204 });
+                    }
+                  };
+                }
+              };
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const p = deployment.removeDeployment(config, deploymentResource);
+  t.equal(p instanceof Promise, true, 'should return a promise');
+
+  p.then(() => {
+    t.pass();
+    t.end();
+  });
+});

--- a/test/deployment-test.js
+++ b/test/deployment-test.js
@@ -120,8 +120,6 @@ test('deploy - created already - but error', (t) => {
     }
   };
 
-  let call = 0;
-
   const config = {
     projectName: 'my Project',
     namespace: {

--- a/test/enrich-resources-test.js
+++ b/test/enrich-resources-test.js
@@ -105,3 +105,50 @@ test('enrich-resource - knative enrichers', (t) => {
     t.end();
   });
 });
+
+test('enrich-resource - deployment enrichers', (t) => {
+  let i = 0;
+  const enrichResource = proxyquire('../lib/enrich-resources', {
+    './load-enrichers': () => {
+      return {
+        'deployment-config': () => {
+          i++;
+          t.fail('should not get called');
+        },
+        deployment: () => {
+          i++;
+          t.pass('should get called');
+        },
+        route: () => {
+          i++;
+          t.pass('should get called');
+        },
+        service: () => {
+          i++;
+          t.pass('should get called');
+        },
+        labels: () => {
+          i++;
+          t.pass('should get called');
+        },
+        'git-info': () => {
+          i++;
+          t.pass('should get called');
+        },
+        'health-check': () => {
+          i++;
+          t.pass('should get called');
+        }
+      };
+    }
+  });
+
+  const p = enrichResource({ useDeployment: true }, []);
+  t.ok(p instanceof Promise, 'should return a promise');
+
+  p.then(() => {
+    t.equal(i, 6, 'should have 6 enrichers');
+    t.pass('success');
+    t.end();
+  });
+});

--- a/test/goals/apply-resources-test.js
+++ b/test/goals/apply-resources-test.js
@@ -20,6 +20,7 @@ test('apply resource test', (t) => {
     { kind: 'Service', apiVersion: 'serving.knative.dev/v1' },
     { kind: 'Route', apiVersion: 'v1' },
     { kind: 'DeploymentConfig', apiVersion: 'v1' },
+    { kind: 'Deployment', apiVersion: 'v1' },
     { kind: 'Secret', apiVersion: 'v1' },
     { kind: 'Ingress', apiVersion: 'v1' },
     { kind: 'ConfigMap', apiVersion: 'v1' },
@@ -34,6 +35,9 @@ test('apply resource test', (t) => {
     '../routes': mockedPromiseResolve,
     '../deployment-config': {
       deploy: mockedPromiseResolve
+    },
+    '../deployment': {
+      applyDeployment: mockedPromiseResolve
     },
     '../secrets': mockedPromiseResolve,
     '../ingress': mockedPromiseResolve,

--- a/test/goals/undeploy-test.js
+++ b/test/goals/undeploy-test.js
@@ -72,6 +72,11 @@ test('return list items', (t) => {
         metadata: metadata
       },
       {
+        kind: 'Deployment',
+        apiVersion: 'v1',
+        metadata: metadata
+      },
+      {
         kind: 'Ingress',
         apiVersion: 'v1',
         metadata: metadata
@@ -181,6 +186,9 @@ test('return list items', (t) => {
     },
     '../deployment-config': {
       undeploy: () => { return Promise.resolve(); }
+    },
+    '../deployment': {
+      removeDeployment: () => { return Promise.resolve(); }
     }
   });
 


### PR DESCRIPTION
This adds the ability for a user to use a Deployment instead of a DeploymentConfig using the `--useDeployment` flag when doing a deployment.

This flag can also be used during the `resource`, `apply-resource`, `deploy` and `undeploy` goals


fixes #476 