### PR TITLE
feat: deprecate apiServer and replace with server

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ This connect to Minikubes docker server, create a new container and then deploy 
 
 Nodeshift uses the [Openshift Rest Client](https://github.com/nodeshift/openshift-rest-client) under the hood to make all REST calls to the cluster.  By default, the rest client will look at your `~/.kube/config` file to authenticate you.  This file will be created when you do an `oc login`.
 
-If you don't want to use `oc` to login first, you can pass in a username, password, and the apiServer of the cluster to authenticate against.  If you are using a cluster with a self-signed certificate(like code ready containers), then you will need to add the `insecure` flag.
+If you don't want to use `oc` to login first, you can pass in a username, password, and the server of the cluster to authenticate against.  If you are using a cluster with a self-signed certificate(like code ready containers), then you will need to add the `insecure` flag.
 
 Also note, that when accessing the cluster this way,  the namespace will default to `default`.  If you need to target another namespace,  use the `namespace.name` flag.  Just make sure the user you use has the appropriate permissions.
 
 An example of this might look something like this:
 
-`npx nodeshift --username developer --password developer --apiServer https://apiserver_for_cluster --insecure --namespace.name nodejs-examples`
+`npx nodeshift --username developer --password developer --server https://apiserver_for_cluster --insecure --namespace.name nodejs-examples`
 
 
 ## Advanced Options
@@ -194,8 +194,11 @@ username to pass into the openshift rest client for logging in with the API Serv
 #### password
 password to pass into the openshift rest client for logging in with the API Server.
 
-#### apiServer
-apiServer to pass into the openshift rest client for logging in with the API Server.
+#### server
+server to pass into the openshift rest client for logging in with the API Server.
+
+#### apiServer - Deprecated
+Use server instead. apiServer to pass into the openshift rest client for logging in with the API Server.
 
 #### insecure
 flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false.
@@ -282,7 +285,9 @@ Shows the below help
                                      logging in                                   [string]
             --password               password to pass into the openshift rest client for
                                      logging in                                   [string]
-            --apiServer              server address to pass into the openshift rest client
+            --apiServer              Deprecated - use the "server" flag instead. server address to pass into the openshift rest client
+                                     for logging in                               [string]
+            --server                 server address to pass into the openshift rest client
                                      for logging in                               [string]
             --insecure               flag to pass into the openshift rest client for
                                      logging in with a self signed cert.  Only used with

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -59,6 +59,10 @@ yargs
     type: 'string'
   })
   .options('apiServer', {
+    describe: 'Deprecated - use the "server" flag instead. server address to pass into the openshift rest client for logging in',
+    type: 'string'
+  })
+  .options('server', {
     describe: 'server address to pass into the openshift rest client for logging in',
     type: 'string'
   })
@@ -207,7 +211,11 @@ function createOptions (argv) {
   // Not sure about storing these
   options.username = argv.username;
   options.password = argv.password;
+  // TODO: Remove in the next major release
   options.apiServer = argv.apiServer;
+
+  options.server = argv.server;
+
   options.insecure = argv.insecure === true || argv.insecure === 'true';
 
   options.knative = argv.knative === true || argv.knative === 'true';

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ const cli = require('./bin/cli');
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
-  @param {string} [options.apiServer] - apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {object} [options.namespace] -
@@ -53,7 +54,8 @@ function deploy (options = {}) {
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
-  @param {string} [options.apiServer] - apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {object} [options.namespace] -
@@ -85,7 +87,8 @@ function resource (options = {}) {
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
-  @param {string} [options.apiServer] - apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {object} [options.namespace] -
@@ -121,7 +124,8 @@ function applyResource (options = {}) {
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
-  @param {string} [options.apiServer] - apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
@@ -157,7 +161,8 @@ function undeploy (options = {}) {
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
-  @param {string} [options.apiServer] - apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files

--- a/lib/config/nodeshift-config.js
+++ b/lib/config/nodeshift-config.js
@@ -42,7 +42,15 @@ async function setup (options = {}) {
   // If there is a configLocation string, pass it in
   if (options.configLocation) {
     restClientConfig = options.configLocation;
-  } else if (options.apiServer) {
+  } else if (options.apiServer || options.server) {
+    if (options.apiServer) {
+      logger.warning('The --apiServer flag is Deprecated, use the --server flag instead');
+    }
+
+    if (options.server) {
+      // TODO: remove this If in the next major release and just use options.server
+      options.apiServer = options.server;
+    }
     // pass in the apiServer, username and password if one is specified
     /*
       should look a little like this:

--- a/test/config-tests/nodeshift-config-test.js
+++ b/test/config-tests/nodeshift-config-test.js
@@ -534,6 +534,44 @@ test('nodeshift-config options username, pasword, apiServer insecure(true)', (t)
   });
 });
 
+test('nodeshift-config options username, pasword, server insecure(true)', (t) => {
+  const options = {
+    server: 'https://server',
+    username: 'developer',
+    password: 'developer',
+    insecure: true
+  };
+
+  const nodeshiftConfig = proxyquire('../../lib/config/nodeshift-config', {
+    'openshift-rest-client': {
+      OpenshiftClient: (settings) => {
+        t.equal(settings.config.url, options.server, 'should be passed in');
+        t.equal(settings.config.auth.username, options.username, 'should be passed in');
+        t.equal(settings.config.auth.password, options.password, 'should be passed in');
+        t.equal(settings.config.insecureSkipTlsVerify, options.insecure, 'should be passed in');
+        return Promise.resolve({
+          kubeconfig: {
+            getCurrentContext: () => {
+              return 'nodey/ip/other';
+            },
+            getCurrentCluster: () => {
+              return { server: 'http://mock-cluster' };
+            },
+            getContexts: () => {
+              return [{ name: 'nodey/ip/other', namespace: 'test-namespace' }];
+            }
+          }
+        });
+      }
+    }
+  });
+
+  nodeshiftConfig(options).then((config) => {
+    t.pass();
+    t.end();
+  });
+});
+
 test('nodeshift-config options username, pasword, apiServer, insecure(false)', (t) => {
   const options = {
     apiServer: 'https://server',


### PR DESCRIPTION
the flag `server` is more inline with what Openshift and the `oc` command use