### PR TITLE
feat:  add a token flag to pass in an auth token for API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ An example of this might look something like this:
 
 `npx nodeshift --username developer --password developer --server https://apiserver_for_cluster --insecure --namespace.name nodejs-examples`
 
+You can also pass in a valid auth token using the `token` flag.  If both a token and username/password is specified,  the token will take the preference.
+
+`npx nodeshift --token 123456789  --server https://apiserver_for_cluster --insecure --namespace.name nodejs-examples`
 
 ## Advanced Options
 
@@ -187,6 +190,9 @@ Changes the default location of where to look for your project. Defaults to your
 
 #### configLocation
 This option is passed through to the [Openshift Rest Client](https://www.npmjs.com/package/openshift-rest-client).  Defaults to the `~/.kube/config`
+
+#### token
+Auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
 
 #### username
 username to pass into the openshift rest client for logging in with the API Server.
@@ -281,6 +287,8 @@ Shows the below help
                            cluster.  At the moment only Minikube is supported.
                                                                                  [boolean]
             --configLocation         change the default location of the config    [string]
+            --token                  auth token to pass into the openshift rest client for
+                                     logging in.  Overrides the username/password [string]
             --username               username to pass into the openshift rest client for
                                      logging in                                   [string]
             --password               password to pass into the openshift rest client for

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -50,6 +50,10 @@ yargs
     describe: 'change the default location of the config',
     type: 'string'
   })
+  .options('token', {
+    describe: 'auth token to pass into the openshift rest client for logging in.  Overrides the username/password',
+    type: 'string'
+  })
   .options('username', {
     describe: 'username to pass into the openshift rest client for logging in',
     type: 'string'
@@ -215,6 +219,8 @@ function createOptions (argv) {
   options.apiServer = argv.apiServer;
 
   options.server = argv.server;
+
+  options.token = argv.token;
 
   options.insecure = argv.insecure === true || argv.insecure === 'true';
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const cli = require('./bin/cli');
 
   @param {object} [options] - Options object for the deploy function
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
+  @param {string} [options.token] - auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
@@ -52,6 +53,7 @@ function deploy (options = {}) {
 
   @param {object} [options] - Options object for the resource function
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
+  @param {string} [options.token] - auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
@@ -85,6 +87,7 @@ function resource (options = {}) {
 
   @param {object} [options] - Options object for the apply-resource function
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
+  @param {string} [options.token] - auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
@@ -122,6 +125,7 @@ function applyResource (options = {}) {
 
   @param {object} [options] - Options object for the undeploy function
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
+  @param {string} [options.token] - auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
@@ -159,6 +163,7 @@ function undeploy (options = {}) {
 
   @param {object} [options] - Options object for the build function
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
+  @param {string} [options.token] - auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
   @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server

--- a/lib/config/nodeshift-config.js
+++ b/lib/config/nodeshift-config.js
@@ -62,12 +62,22 @@ async function setup (options = {}) {
         }
       }
     */
-    restClientConfig = {
-      url: options.apiServer,
-      auth: {
+
+    let auth;
+
+    if (options.token) {
+      auth = {
+        token: options.token
+      };
+    } else {
+      auth = {
         username: options.username,
         password: options.password
-      },
+      };
+    }
+    restClientConfig = {
+      url: options.apiServer,
+      auth: auth,
       insecureSkipTlsVerify: options.insecure
     };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9441,9 +9441,9 @@
       }
     },
     "openshift-rest-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/openshift-rest-client/-/openshift-rest-client-5.0.0.tgz",
-      "integrity": "sha512-jUxJuSS28xNu5bE8xGFA3ajhCjH3evK3j7RLsGIBbxWompBDK07c17pMrdlvJTueOFAF+JH6cY/gQCBnRi2aVA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/openshift-rest-client/-/openshift-rest-client-5.1.0.tgz",
+      "integrity": "sha512-OqwBXykap83y40j9bmyjdZ5ksOrW2iQ74UkOHWCeRaSvdjb/ipQDcMFp81+geRiSsg126/z6n+TCLTnJHngGqA==",
       "requires": {
         "kubernetes-client": "9.0.0",
         "request": "~2.88.2"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash": "^4.17.20",
     "minimatch": "^3.0.4",
     "mkdirp": "^1.0.3",
-    "openshift-rest-client": "~5.0.0",
+    "openshift-rest-client": "~5.1.0",
     "parse-gitignore": "^1.0.1",
     "tar": "~6.0.5",
     "yargs": "^16.2.0"

--- a/test/config-tests/nodeshift-config-test.js
+++ b/test/config-tests/nodeshift-config-test.js
@@ -608,3 +608,77 @@ test('nodeshift-config options username, pasword, apiServer, insecure(false)', (
     t.end();
   });
 });
+
+test('nodeshift-config options token', (t) => {
+  const options = {
+    apiServer: 'https://server',
+    token: '123456'
+  };
+
+  const nodeshiftConfig = proxyquire('../../lib/config/nodeshift-config', {
+    'openshift-rest-client': {
+      OpenshiftClient: (settings) => {
+        t.equal(settings.config.url, options.apiServer, 'should be passed in');
+        t.equal(settings.config.auth.token, options.token, 'should be passed in');
+        t.equal(settings.config.insecureSkipTlsVerify, undefined, 'should be passed in');
+        return Promise.resolve({
+          kubeconfig: {
+            getCurrentContext: () => {
+              return 'nodey/ip/other';
+            },
+            getCurrentCluster: () => {
+              return { server: 'http://mock-cluster' };
+            },
+            getContexts: () => {
+              return [{ name: 'nodey/ip/other', namespace: 'test-namespace' }];
+            }
+          }
+        });
+      }
+    }
+  });
+
+  nodeshiftConfig(options).then((config) => {
+    t.pass();
+    t.end();
+  });
+});
+
+test('nodeshift-config options username, pasword, token, apiServer, insecure(false)', (t) => {
+  const options = {
+    apiServer: 'https://server',
+    username: 'developer',
+    password: 'developer',
+    token: '123456'
+  };
+
+  const nodeshiftConfig = proxyquire('../../lib/config/nodeshift-config', {
+    'openshift-rest-client': {
+      OpenshiftClient: (settings) => {
+        t.equal(settings.config.url, options.apiServer, 'should be passed in');
+        t.equal(settings.config.auth.username, undefined, 'should be passed in');
+        t.equal(settings.config.auth.password, undefined, 'should be passed in');
+        t.equal(settings.config.auth.token, options.token, 'should be passed in');
+        t.equal(settings.config.insecureSkipTlsVerify, undefined, 'should be passed in');
+        return Promise.resolve({
+          kubeconfig: {
+            getCurrentContext: () => {
+              return 'nodey/ip/other';
+            },
+            getCurrentCluster: () => {
+              return { server: 'http://mock-cluster' };
+            },
+            getContexts: () => {
+              return [{ name: 'nodey/ip/other', namespace: 'test-namespace' }];
+            }
+          }
+        });
+      }
+    }
+  });
+
+  nodeshiftConfig(options).then((config) => {
+    t.pass();
+    t.end();
+  });
+});


### PR DESCRIPTION
This adds the `token` flag,  which allows a user to pass a auth token to the openshift rest client.

This also updates the Openshift Rest Client to the latest(5.1.0) which includes the token feature