### PR TITLE
fix(config): Allow scoped applications in the package name.

### DIFF
--- a/lib/config/nodeshift-config.js
+++ b/lib/config/nodeshift-config.js
@@ -127,11 +127,15 @@ async function setup (options = {}) {
 
   logger.info(`using namespace ${config.namespace.name} at ${kubeConfig.getCurrentCluster().server}`);
 
-  if (!projectPackage.name.match(/^[a-z][0-9a-z-]+[0-9a-z]$/)) {
+  if (!projectPackage.name.match(/^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/)) {
     throw new Error('"name" in package.json can only consist lower-case letters, numbers, and dashes. It must start with a letter and can\'t end with a -.');
   }
 
-  options.outputImageStreamName = options.outputImageStreamName || projectPackage.name;
+  // If they are using a @scoped package like "@org/package", we need to strip off the @ symbol and convert it to
+  // something like "org-package"
+  const projectName = projectPackage.name.replace('@', '').replace('/', '-');
+
+  options.outputImageStreamName = options.outputImageStreamName || projectName;
   options.outputImageStreamTag = options.outputImageStreamTag || 'latest';
 
   // TODO: do build strategy here
@@ -155,10 +159,10 @@ async function setup (options = {}) {
     // We don't want to hard code the port later, so add it here for later use in the application descriptors
     // Make sure it is a number
     port: options.deploy && options.deploy.port ? parseInt(options.deploy.port, 10) : 8080,
-    projectName: projectPackage.name,
+    projectName: projectName,
     projectVersion: projectPackage.version || '0.0.0',
     // Since we are only doing s2i builds(atm), append the s2i bit to the end
-    buildName: `${projectPackage.name}-s2i`, // TODO(lholmquist):  this should probably change?
+    buildName: `${projectName}-s2i`, // TODO(lholmquist):  this should probably change?
     // Load an instance of the Openshift Rest Client, https://www.npmjs.com/package/openshift-rest-client
     openshiftRestClient: restClient,
     dockerClient

--- a/test/config-tests/nodeshift-config-test.js
+++ b/test/config-tests/nodeshift-config-test.js
@@ -168,6 +168,65 @@ test('nodeshift-config no package.json', (t) => {
   });
 });
 
+test('nodeshift-config valid "@scope name" in package.json', (t) => {
+  const nodeshiftConfig = proxyquire('../../lib/config/nodeshift-config', {
+    'openshift-rest-client': {
+      OpenshiftClient: () => {
+        return Promise.resolve({
+          kubeconfig: {
+            getCurrentContext: () => {
+              return 'nodey/ip/other';
+            },
+            getCurrentCluster: () => {
+              return { server: 'http://mock-cluster' };
+            },
+            getContexts: () => {
+              return [{ name: 'nodey/ip/other', namespace: 'test-namespace' }];
+            }
+          }
+        });
+      }
+    }
+  });
+
+  const tmpDir = require('os').tmpdir();
+  const join = require('path').join;
+  const fs = require('fs');
+
+  const options = {
+    projectLocation: join(tmpDir, 'nodeshift-valid-scope-package-name-test')
+  };
+
+  if (!fs.existsSync(options.projectLocation)) {
+    fs.mkdirSync(options.projectLocation);
+  }
+
+  // Create a temp package that has an invalid name, but extends the example JSON
+  fs.writeFileSync(
+    join(options.projectLocation, 'package.json'),
+    JSON.stringify(
+      Object.assign(
+        {},
+        require('../../examples/sample-project/package.json'),
+        {
+          name: '@org/pkg'
+        }
+      )
+    )
+  );
+
+  nodeshiftConfig(options)
+    .then(config => {
+      console.log(config);
+      t.pass('Valid Scoped Name');
+      t.end();
+    })
+    .catch((err) => {
+      t.fail(err);
+      t.end();
+    });
+});
+
 test('nodeshift-config invalid "name" in package.json', (t) => {
   const nodeshiftConfig = proxyquire('../../lib/config/nodeshift-config', {
     'openshift-rest-client': {

--- a/test/config-tests/nodeshift-config-test.js
+++ b/test/config-tests/nodeshift-config-test.js
@@ -217,7 +217,8 @@ test('nodeshift-config valid "@scope name" in package.json', (t) => {
 
   nodeshiftConfig(options)
     .then(config => {
-      console.log(config);
+      t.equal(config.projectName, 'org-pkg', 'modified name');
+      t.equal(config.projectPackage.name, '@org/pkg', 'not modified');
       t.pass('Valid Scoped Name');
       t.end();
     })


### PR DESCRIPTION
* This modifies the logic that was used to determine if an applications package name was valid.  Previously, nodeshift would error when using scoped packages.  Since @org/pkg is valid in npm,  this is now valid with nodeshift.  scoped package names will be updated to org-pkg for the Openshift Objects the CLI creates.

fixes #538