### PR TITLE
feat(enricher): Adds the rh-metering flag for adding Red Hat Runtimes metering to your application.

### DIFF
--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -212,6 +212,16 @@ function createOptions (argv) {
 
   options.useDeployment = argv.useDeployment;
 
+  // User wants to add red hat metering
+  // This could be just use defaults based on the rh node image
+  // or can override the node version
+  // Keeping this feature undocumented for now
+  options.metering = argv['rh-metering'];
+
+  if (Array.isArray(options.metering)) {
+    options.metering = helpers.parseMeteringEntry(options.metering);
+  }
+
   // Not sure about storing these
   options.username = argv.username;
   options.password = argv.password;

--- a/lib/config/nodeshift-config.js
+++ b/lib/config/nodeshift-config.js
@@ -27,6 +27,9 @@ const { promisify } = require('util');
 const readFile = promisify(fs.readFile);
 const _ = require('lodash');
 
+const DEFAULT_DOCKER_IMAGE = 'registry.access.redhat.com/ubi8/nodejs-14';
+const DEFAULT_DOCKER_TAG = 'latest';
+
 async function setup (options = {}) {
   options.nodeshiftDirectory = '.nodeshift';
   options.projectLocation = options.projectLocation || process.cwd();
@@ -152,6 +155,9 @@ async function setup (options = {}) {
     logger.warning(`An unknown build strategy, ${options.build.strategy}, was specified, using the Source strategy instead`);
     options.build.strategy = 'Source';
   }
+
+  options.dockerImge = options.dockerImage || DEFAULT_DOCKER_IMAGE;
+  options.imageTag = options.imageTag || DEFAULT_DOCKER_TAG;
 
   // Return a new object with the config, the rest client and other data.
   const result = Object.assign({}, config, {

--- a/lib/definitions/build-strategy.js
+++ b/lib/definitions/build-strategy.js
@@ -20,10 +20,6 @@
 
 const logger = require('../common-log')();
 
-// Perhaps we should define this in another location
-const DEFAULT_DOCKER_IMAGE = 'registry.access.redhat.com/ubi8/nodejs-14';
-const DEFAULT_DOCKER_TAG = 'latest';
-
 // Default docker image for web-apps
 const DEFAULT_WEB_APP_DOCKER_IMAGE = 'nodeshift/ubi8-s2i-web-app';
 // Adding in the DOCKER build strategy
@@ -51,10 +47,8 @@ module.exports = (options) => {
     options.dockerImage = options.webApp ? DEFAULT_WEB_APP_DOCKER_IMAGE : options.dockerImage;
 
     // Just doing the source strategy
-    const dockerImage = options.dockerImage ? options.dockerImage : DEFAULT_DOCKER_IMAGE;
-    const dockerTag = options.imageTag ? options.imageTag : DEFAULT_DOCKER_TAG;
-    logger.info(`Using s2i image ${dockerImage} with tag ${dockerTag}`);
-    const dockerImageName = `${dockerImage}:${dockerTag}`;
+    logger.info(`Using s2i image ${options.dockerImage} with tag ${options.imageTag}`);
+    const dockerImageName = `${options.dockerImage}:${options.imageTag}`;
 
     strategy.sourceStrategy = {
       env: env,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -110,6 +110,14 @@ function generateUUID () {
   return Math.random().toString(26).slice(2);
 }
 
+function parseMeteringEntry (arr) {
+  return arr.reduce((accum, curr, index, sourceArray) => {
+    if (typeof curr === 'object') {
+      return Object.assign({}, accum, curr);
+    }
+  }, {});
+}
+
 module.exports = {
   yamlToJson: yamlToJson,
   normalizeFileList: normalizeFileList,
@@ -121,5 +129,6 @@ module.exports = {
   awaitRequest,
   parseIgnoreFile,
   matchRule,
-  generateUUID
+  generateUUID,
+  parseMeteringEntry
 };

--- a/lib/resource-enrichers/default-enrichers.json
+++ b/lib/resource-enrichers/default-enrichers.json
@@ -1,3 +1,3 @@
 [
-  "deployment-config", "deployment-env", "service", "route", "labels", "git-info", "health-check", "runtime-label"
+  "deployment-config", "deployment-env", "service", "route", "labels", "git-info", "health-check", "runtime-label", "meterting"
 ]

--- a/lib/resource-enrichers/deployment-enrichers.json
+++ b/lib/resource-enrichers/deployment-enrichers.json
@@ -1,3 +1,3 @@
 [
-  "deployment", "service", "route", "labels", "git-info", "health-check", "runtime-label"
+  "deployment", "service", "route", "labels", "git-info", "health-check", "runtime-label", "meterting"
 ]

--- a/lib/resource-enrichers/metering-enricher.js
+++ b/lib/resource-enrichers/metering-enricher.js
@@ -67,7 +67,7 @@ async function addMeteringInfo (config, resourceList) {
         return resource;
       }
 
-      const nodeVersion = config.metering['component-version'] ? config.metering['component-version'] : parseNodeImage(config.dockerImage);
+      const nodeVersion = config.metering.nodeVersion ? config.metering.nodeVersion : parseNodeImage(config.dockerImage);
 
       resource.spec.template.metadata.labels = _.merge({}, METERING_LABELS, resource.spec.template.metadata.labels);
       resource.spec.template.metadata.labels['com.redhat.component-version'] = nodeVersion;

--- a/lib/resource-enrichers/metering-enricher.js
+++ b/lib/resource-enrichers/metering-enricher.js
@@ -1,0 +1,86 @@
+/*
+ *
+ *  Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+'use strict';
+
+// Enricher for adding metering metadata
+const METERING_LABELS = {
+  'com.redhat.component-name': 'Node.js',
+  'com.redhat.component-type': 'application',
+  'com.redhat.component-version': '14.x.x', // Need to look at the image
+  'com.redhat.product-name': 'Red_Hat_Runtimes',
+  'com.redhat.product-version': '2021/Q1' // Node 14 - 2021/Q1 Node 16 2021/Q4(?)
+};
+
+const _ = require('lodash');
+
+function parseNodeMajor (nodeVersion) {
+  return nodeVersion.split('.')[0];
+}
+
+function getProductVersion (nodeVersion) {
+  let productVersion;
+  switch (parseNodeMajor(nodeVersion)) {
+    case '14':
+      productVersion = '2021/Q1';
+      break;
+    default:
+      productVersion = 'unknown';
+      break;
+  }
+
+  return productVersion;
+}
+
+function parseNodeImage (imageName) {
+  const split = imageName.split('/');
+
+  const justNode = split.find((val) => {
+    return val.includes('nodejs');
+  });
+
+  const nodeVersion = justNode.split('-')[1];
+  return nodeVersion;
+}
+
+async function addMeteringInfo (config, resourceList) {
+  return resourceList.map((resource) => {
+    if (resource.kind === 'DeploymentConfig' || resource.kind === 'Deployment') {
+      // Check that the metering flag was added
+      // Also check that a "Red Hat" image is being used?
+      if (!config.metering) {
+        return resource;
+      }
+
+      const nodeVersion = config.metering['component-version'] ? config.metering['component-version'] : parseNodeImage(config.dockerImage);
+
+      resource.spec.template.metadata.labels = _.merge({}, METERING_LABELS, resource.spec.template.metadata.labels);
+      resource.spec.template.metadata.labels['com.redhat.component-version'] = nodeVersion;
+      resource.spec.template.metadata.labels['com.redhat.product-version'] = getProductVersion(nodeVersion);
+
+      return resource;
+    }
+
+    return resource;
+  });
+}
+
+module.exports = {
+  enrich: addMeteringInfo,
+  name: 'metering'
+};

--- a/test/definitions-tests/build-strategy-test.js
+++ b/test/definitions-tests/build-strategy-test.js
@@ -4,7 +4,7 @@ const test = require('tape');
 const buildStrategy = require('../../lib/definitions/build-strategy');
 
 test('default strategy', (t) => {
-  const result = buildStrategy({ buildStrategy: 'Source' });
+  const result = buildStrategy({ buildStrategy: 'Source', dockerImage: 'registry.access.redhat.com/ubi8/nodejs-14', imageTag: 'latest' });
 
   t.equal(result.type, 'Source', 'default is Source type');
   t.ok(result.sourceStrategy, 'Source strategy object');
@@ -15,7 +15,7 @@ test('default strategy', (t) => {
 });
 
 test('strategy with changed dockerTag', (t) => {
-  const result = buildStrategy({ imageTag: '1-20', buildStrategy: 'Source' });
+  const result = buildStrategy({ imageTag: '1-20', buildStrategy: 'Source', dockerImage: 'registry.access.redhat.com/ubi8/nodejs-14' });
   t.equal(result.sourceStrategy.from.name, 'registry.access.redhat.com/ubi8/nodejs-14:1-20', 'docker image should be 1-20 ubi8/nodejs-14 image');
   t.end();
 });
@@ -45,7 +45,7 @@ test('strategy with changed incremental to false', (t) => {
 });
 
 test('strategy with change dockerImage', (t) => {
-  const result = buildStrategy({ dockerImage: 'lholmquist/centos7-s2i-nodejs', buildStrategy: 'Source' });
+  const result = buildStrategy({ dockerImage: 'lholmquist/centos7-s2i-nodejs', buildStrategy: 'Source', imageTag: 'latest' });
 
   t.equal(result.sourceStrategy.from.name, 'lholmquist/centos7-s2i-nodejs:latest', 'docker image should be latest lholmquist image');
   t.end();
@@ -68,21 +68,21 @@ test('strategy with env vars', (t) => {
 });
 
 test('defaults to using latest ubi8/nodejs-14 s2i builder image', t => {
-  const result = buildStrategy({ buildStrategy: 'Source' });
+  const result = buildStrategy({ buildStrategy: 'Source', dockerImage: 'registry.access.redhat.com/ubi8/nodejs-14', imageTag: 'latest' });
 
   t.equals(result.sourceStrategy.from.name, 'registry.access.redhat.com/ubi8/nodejs-14:latest');
   t.end();
 });
 
 test('accepts a node version using imageTag option', t => {
-  const result = buildStrategy({ imageTag: '1-20', buildStrategy: 'Source' });
+  const result = buildStrategy({ imageTag: '1-20', buildStrategy: 'Source', dockerImage: 'registry.access.redhat.com/ubi8/nodejs-14' });
 
   t.equals(result.sourceStrategy.from.name, 'registry.access.redhat.com/ubi8/nodejs-14:1-20');
   t.end();
 });
 
 test('strategy with web-app option enabled', (t) => {
-  const result = buildStrategy({ webApp: true, buildStrategy: 'Source' });
+  const result = buildStrategy({ webApp: true, buildStrategy: 'Source', imageTag: 'latest' });
 
   t.equal(result.sourceStrategy.from.name, 'nodeshift/ubi8-s2i-web-app:latest', 'docker image should be latest web-app image');
   t.end();

--- a/test/enricher-tests/metering-enricher-test.js
+++ b/test/enricher-tests/metering-enricher-test.js
@@ -141,7 +141,7 @@ test('metering enricher - metering, override node version', async (t) => {
     }
   ];
 
-  const me = await meteringEnricher.enrich({ ...config, metering: { 'component-version': '14.15.4' } }, resourceList);
+  const me = await meteringEnricher.enrich({ ...config, metering: { nodeVersion: '14.15.4' } }, resourceList);
 
   t.equal(Array.isArray(me), true, 'should return an array');
   t.notEqual(me, resourceList, 'should not be equal');
@@ -178,7 +178,7 @@ test('metering enricher - metering, unknown node version', async (t) => {
     }
   ];
 
-  const me = await meteringEnricher.enrich({ ...config, metering: { 'component-version': '16.1.0' } }, resourceList);
+  const me = await meteringEnricher.enrich({ ...config, metering: { nodeVersion: '16.1.0' } }, resourceList);
 
   t.equal(Array.isArray(me), true, 'should return an array');
   t.notEqual(me, resourceList, 'should not be equal');

--- a/test/enricher-tests/metering-enricher-test.js
+++ b/test/enricher-tests/metering-enricher-test.js
@@ -1,0 +1,193 @@
+'use strict';
+
+const test = require('tape');
+
+const meteringEnricher = require('../../lib/resource-enrichers/metering-enricher');
+const config = {
+  projectName: 'Project Name',
+  version: '1.0.0',
+  namespace: {
+    name: 'namespace'
+  }
+};
+
+test('metering enricher - no metering', (t) => {
+  const resourceList = [
+    {
+      kind: 'Service',
+      metadata: {
+        name: 'service meta'
+      }
+    },
+    {
+      kind: 'Deployment',
+      metadata: {
+        name: 'deploymentName'
+      },
+      spec: {
+        template: {
+          metadata: {
+            labels: {}
+          }
+        }
+      }
+    }
+  ];
+
+  t.ok(meteringEnricher.enrich, 'has an enrich property');
+  t.equal(typeof meteringEnricher.enrich, 'function', 'is a function');
+
+  t.ok(meteringEnricher.name, 'has an name property');
+  t.equal(meteringEnricher.name, 'metering');
+
+  const p = meteringEnricher.enrich({ ...config, metering: false }, resourceList);
+  t.ok(p instanceof Promise, 'enricher should return a promise');
+
+  p.then((me) => {
+    t.equal(Array.isArray(me), true, 'should return an array');
+    t.equal(me.length, 2, 'array should have 1 things');
+    t.equal(me[1].spec.template.metadata.labels['com.redhat.component-name'], undefined, 'should be no metering labels');
+    t.equal(me[1].spec.template.metadata.labels['com.redhat.component-type'], undefined, 'should be no metering labels');
+    t.equal(me[1].spec.template.metadata.labels['com.redhat.component-version'], undefined, 'should be no metering labels');
+    t.equal(me[1].spec.template.metadata.labels['com.redhat.product-name'], undefined, 'should be no metering labels');
+    t.equal(me[1].spec.template.metadata.labels['com.redhat.product-version'], undefined, 'should be no metering labels');
+    t.end();
+  });
+});
+
+test('metering enricher - no deployment', (t) => {
+  const resourceList = [
+    {
+      kind: 'Service',
+      metadata: {
+        name: 'service meta'
+      }
+    }
+  ];
+
+  t.ok(meteringEnricher.enrich, 'has an enrich property');
+  t.equal(typeof meteringEnricher.enrich, 'function', 'is a function');
+
+  t.ok(meteringEnricher.name, 'has an name property');
+  t.equal(meteringEnricher.name, 'metering');
+
+  const p = meteringEnricher.enrich({ ...config, metering: true }, resourceList);
+  t.ok(p instanceof Promise, 'enricher should return a promise');
+
+  p.then((me) => {
+    t.equal(Array.isArray(me), true, 'should return an array');
+    t.equal(me.length, 1, 'array should have 1 things');
+    t.end();
+  });
+});
+
+test('metering enricher - metering', async (t) => {
+  const resourceList = [
+    {
+      kind: 'Service',
+      metadata: {
+        name: 'service meta'
+      }
+    },
+    {
+      kind: 'Deployment',
+      metadata: {
+        name: 'deploymentName'
+      },
+      spec: {
+        template: {
+          metadata: {
+            labels: {}
+          }
+        }
+      }
+    }
+  ];
+
+  const me = await meteringEnricher.enrich({ ...config, metering: true, dockerImage: 'registry.access.redhat.com/ubi8/nodejs-14' }, resourceList);
+
+  t.equal(Array.isArray(me), true, 'should return an array');
+  t.notEqual(me, resourceList, 'should not be equal');
+  t.equal(me[1].kind, 'Deployment', 'should have the deployment type');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.component-name'], 'Node.js', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.component-type'], 'application', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.component-version'], '14', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.product-name'], 'Red_Hat_Runtimes', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.product-version'], '2021/Q1', 'should be metering labels');
+
+  t.end();
+});
+
+test('metering enricher - metering, override node version', async (t) => {
+  const resourceList = [
+    {
+      kind: 'Service',
+      metadata: {
+        name: 'service meta'
+      }
+    },
+    {
+      kind: 'Deployment',
+      metadata: {
+        name: 'deploymentName'
+      },
+      spec: {
+        template: {
+          metadata: {
+            labels: {}
+          }
+        }
+      }
+    }
+  ];
+
+  const me = await meteringEnricher.enrich({ ...config, metering: { 'component-version': '14.15.4' } }, resourceList);
+
+  t.equal(Array.isArray(me), true, 'should return an array');
+  t.notEqual(me, resourceList, 'should not be equal');
+  t.equal(me[1].kind, 'Deployment', 'should have the deployment type');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.component-name'], 'Node.js', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.component-type'], 'application', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.component-version'], '14.15.4', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.product-name'], 'Red_Hat_Runtimes', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.product-version'], '2021/Q1', 'should be metering labels');
+
+  t.end();
+});
+
+test('metering enricher - metering, unknown node version', async (t) => {
+  const resourceList = [
+    {
+      kind: 'Service',
+      metadata: {
+        name: 'service meta'
+      }
+    },
+    {
+      kind: 'Deployment',
+      metadata: {
+        name: 'deploymentName'
+      },
+      spec: {
+        template: {
+          metadata: {
+            labels: {}
+          }
+        }
+      }
+    }
+  ];
+
+  const me = await meteringEnricher.enrich({ ...config, metering: { 'component-version': '16.1.0' } }, resourceList);
+
+  t.equal(Array.isArray(me), true, 'should return an array');
+  t.notEqual(me, resourceList, 'should not be equal');
+  t.equal(me[1].kind, 'Deployment', 'should have the deployment type');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.component-name'], 'Node.js', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.component-type'], 'application', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.component-version'], '16.1.0', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.product-name'], 'Red_Hat_Runtimes', 'should be metering labels');
+  t.equal(me[1].spec.template.metadata.labels['com.redhat.product-version'], 'unknown', 'should be metering labels');
+
+  t.end();
+});


### PR DESCRIPTION

* The new flag is `--rh-metering`.  can also be used as `--rh-metering.component-version=NODE_VERSION`

* This is currently an undocumented feature since it is more for those using Red Hat Runtimes build of Node.js