### PR TITLE
feat: nodeshift login with cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ or to use in an npm script
 
 By default, if you run just `nodeshift`, it will run the `deploy` goal, which is a shortcut for running `resource`, `build` and `apply-resource`.
 
+**login** - will login to the cluster
+
+**logout** - will logout of the cluster
+
 **resource** - will parse and create the application resources files on disk
 
 **apply-resource** - does the resource goal and then deploys the resources to your running cluster
@@ -44,6 +48,47 @@ By default, if you run just `nodeshift`, it will run the `deploy` goal, which is
 
 **undeploy** - removes resources that were deployed with the apply-resource command
 
+
+### Using Login and Logout
+
+By default, the Nodeshift CLI will look for a kube config in `~/.kube/config`.  This is usually created when a user does an `oc login`,  but that requires the `oc` to be installed and the extra step of running the `oc login` command.  The Nodeshift CLI allows you to pass a username/password or a valid auth token along with the clusters API server address to authenticate requests without the need to run `oc login` first.
+
+While these parameters can be specified for each command, the `nodeshift login` command helps to simplify that.  You can now run `nodeshift login` with the parameters mentioned to first login, then run the usual `nodeshift deploy` without neededing to add the flags.
+
+CLI Usage - Login:
+
+```
+$ nodeshift login --username=developer --password=password --server=https://api.server
+
+or
+
+$ nodeshift login --token=12345 --server=https://api.server
+```
+
+CLI Usage - Logout
+
+```
+$ nodeshift logout
+```
+
+API usage using async/await would look something like this:
+
+```
+const nodeshift = require('nodeshift');
+
+const options = {
+  username: 'kubeadmin',
+  password: '...',
+  server: '...',
+  insecure: true
+};
+
+(async () => {
+  await nodeshift.login(options);
+  await nodeshift.deploy();
+  await nodeshift.logout();
+})();
+```
 
 ### `.nodeshift` Directory
 
@@ -209,6 +254,9 @@ Use server instead. apiServer to pass into the openshift rest client for logging
 #### insecure
 flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false.
 
+#### forceLogin
+Force a login when using the apiServer login.  Only used with apiServer login.  default to false
+
 #### imageTag
 Specify the tag of the docker image to use for the deployed application. defaults to latest.
 These version tags correspond to the RHSCL tags of the [ubi8/nodejs s2i images](https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/nodejs-14)
@@ -279,6 +327,8 @@ Shows the below help
             nodeshift resource        resource command
             nodeshift apply-resource  apply resource command
             nodeshift undeploy        undeploy resources
+            nodeshift login           login to the cluster
+            nodeshift logout          logout of the cluster
 
         Options:
             --version                Show version number                         [boolean]
@@ -300,6 +350,7 @@ Shows the below help
             --insecure               flag to pass into the openshift rest client for
                                      logging in with a self signed cert.  Only used with
                                      apiServer login                             [boolean]
+            --forceLogin             Force a login when using the apiServer login[boolean]
             --imageTag           The tag of the docker image to use for the deployed
                                 application.                 [string] [default: "latest"]
             --web-app                flag to automatically set the appropriate docker image

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -36,6 +36,9 @@ const kubeUrl = require('../lib/kube-url');
 module.exports = async function run (options) {
   try {
     const config = await nodeshiftConfig(options);
+    if (options.cmd === 'login' || options.cmd === 'logout') {
+      return config;
+    }
     const response = {};
 
     switch (options.cmd) {

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -38,6 +38,8 @@ yargs
   .command('resource', 'resource command', { cmd: { default: 'resource' } }, commandHandler)
   .command('apply-resource', 'apply resource command', { cmd: { default: 'apply-resource' } }, commandHandler)
   .command('undeploy [removeAll]', 'undeploy resources', { cmd: { default: 'undeploy' } }, commandHandler)
+  .command('login', 'login to the cluster', { cmd: { default: 'login' } }, commandHandler)
+  .command('logout', 'logout of the cluster', { cmd: { default: 'logout' } }, commandHandler)
   .option('projectLocation', {
     describe: 'change the default location of the project',
     type: 'string'
@@ -72,6 +74,10 @@ yargs
   })
   .options('insecure', {
     describe: 'flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login',
+    type: 'boolean'
+  })
+  .options('forceLogin', {
+    describe: 'Force a login when using the apiServer login',
     type: 'boolean'
   })
   .options('dockerImage', {
@@ -231,6 +237,8 @@ function createOptions (argv) {
   options.server = argv.server;
 
   options.token = argv.token;
+
+  options.forceLogin = argv.forceLogin;
 
   options.insecure = argv.insecure === true || argv.insecure === 'true';
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,36 @@ const cli = require('./bin/cli');
 */
 
 /**
+  The login function will login
+
+  @param {object} [options] - Options object for the deploy function
+  @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
+  @param {string} [options.token] - auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
+  @param {string} [options.username] - username to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.password] - password to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
+  @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+  @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
+  @returns {Promise<object>} - Returns a JSON Object
+*/
+function login (options = {}) {
+  options.cmd = 'login';
+  return cli(options);
+}
+
+/**
+  The login function will login
+
+  @param {object} [options] - Options object for the deploy function
+  @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
+*/
+function logout (options = {}) {
+  options.cmd = 'logout';
+  return cli(options);
+}
+
+/**
   The deploy function will do the combination of resource, build and apply-resource
 
   @param {object} [options] - Options object for the deploy function
@@ -18,6 +48,7 @@ const cli = require('./bin/cli');
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+  @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
@@ -59,6 +90,7 @@ function deploy (options = {}) {
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+  @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
@@ -93,6 +125,7 @@ function resource (options = {}) {
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+  @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
@@ -131,6 +164,7 @@ function applyResource (options = {}) {
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+  @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.remove] - flag to remove the user created namespace.  Only applicable for the undeploy command.  Must be used with namespace.name
@@ -169,6 +203,7 @@ function undeploy (options = {}) {
   @param {string} [options.apiServer] - @deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.server] - server to pass into the openshift rest client for logging in with the API Server
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+  @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
@@ -192,6 +227,8 @@ function build (options = {}) {
 }
 
 module.exports = {
+  login,
+  logout,
   deploy,
   resource,
   applyResource,

--- a/lib/config/login-config.js
+++ b/lib/config/login-config.js
@@ -1,0 +1,111 @@
+/*
+ *
+ *  Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+'use strict';
+
+const { promisify } = require('util');
+const fs = require('fs');
+const writeFileAsync = promisify(fs.writeFile);
+const readFileAsync = promisify(fs.readFile);
+const helpers = require('../helpers');
+const rmrf = require('../utils/rmrf');
+const { getTokenFromBasicAuth } = require('openshift-rest-client/lib/basic-auth-request');
+const logger = require('../common-log')();
+
+// the flow would be something like this:
+// nodeshift login --token=....... --server=.... [--namepsace=] or nodeshift login --username --password --server [--namespace]
+// nodeshift deploy
+
+// TODO: login like htis oc login --token=sha256~rQmdYxnYg9yRpaP8_L_YTVyo2CsvEMSCWkekq-MLmO0 --server=https://api.ci-ln-g44q3ck-d5d6b.origin-ci-int-aws.dev.rhcloud.com:6443
+// TODO: Login with no params - does this just do the default thing the Openshift rest client does
+
+// TODO: add namespace info when logging in?
+
+// TODO: login from API?
+// TODO: specify an config file instead or an .rc file
+// TODO: some type of validation that a token/user/pass/server has been passed in
+const LOGIN_CONFIG_LOCATION = 'tmp/nodeshift/config';
+
+async function checkForNodeshiftLogin (options) {
+  let loginConfig;
+
+  try {
+    // Check if there is a login.json file available
+    loginConfig = JSON.parse(await readFileAsync(`${options.projectLocation}/${LOGIN_CONFIG_LOCATION}/login.json`));
+    logger.info('login.json file found');
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw new Error(err);
+    // If we made it here, there is no file yet
+    logger.info('No login.json file found');
+  }
+
+  return loginConfig;
+}
+
+async function doNodeshiftLogin (options) {
+  // Check to see if we want to force the login
+  let loginConfig;
+  if (!options.forceLogin) {
+    loginConfig = await checkForNodeshiftLogin(options);
+
+    if (loginConfig) {
+      // TODO: Check the token
+      return loginConfig;
+    }
+  }
+
+  logger.info('logging in with nodeshift cli');
+  // Check to see if there is a token,  if so, use that, if not,  use the username/password if there
+  let authToken;
+  if (options.token) {
+    // use this token
+    authToken = options.token;
+  } else {
+    authToken = await getTokenFromBasicAuth({ user: options.username, password: options.password, url: options.server, insecureSkipTlsVerify: options.insecure });
+  }
+
+  loginConfig = { token: authToken, server: options.server, insecureSkipTlsVerify: options.insecure };
+
+  // Write the token and server to a file
+  // Create the directory
+  await helpers.createDir(`${options.projectLocation}/${LOGIN_CONFIG_LOCATION}`);
+
+  // Now write the json to a file
+  await writeFileAsync(`${options.projectLocation}/${LOGIN_CONFIG_LOCATION}/login.json`, JSON.stringify(loginConfig, null, 2), { encoding: 'utf8' });
+
+  return loginConfig;
+}
+
+async function doNodeshiftLogout (options) {
+  try {
+    // Check if there is a login.json file available
+    await readFileAsync(`${options.projectLocation}/${LOGIN_CONFIG_LOCATION}/login.json`);
+    logger.info('Removing login.json to logout');
+    await rmrf(`${options.projectLocation}/${LOGIN_CONFIG_LOCATION}`);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw new Error(err);
+    // If we made it here, there is no file yet
+    logger.info('No login.json file found');
+  }
+}
+
+module.exports = {
+  doNodeshiftLogin,
+  doNodeshiftLogout,
+  checkForNodeshiftLogin
+};

--- a/lib/config/nodeshift-config.js
+++ b/lib/config/nodeshift-config.js
@@ -20,6 +20,7 @@
 
 const logger = require('../common-log')();
 const kubernetesConfig = require('./kubernetes-config');
+const { doNodeshiftLogin, doNodeshiftLogout, checkForNodeshiftLogin } = require('./login-config');
 const dockerConfig = require('./docker-config');
 const { OpenshiftClient: openshiftRestClient } = require('openshift-rest-client');
 const fs = require('fs');
@@ -40,8 +41,24 @@ async function setup (options = {}) {
 
   logger.info('loading configuration');
   const projectPackage = JSON.parse(await readFile(`${options.projectLocation}/package.json`, { encoding: 'utf8' }));
+
+  if (options.cmd === 'login') {
+    return doNodeshiftLogin(options);
+  } else if (options.cmd === 'logout') {
+    console.log('logout command');
+    return doNodeshiftLogout(options);
+  }
+
   let restClientConfig;
 
+  // TODO: look for the login.json that might be there
+  const loginConfig = await checkForNodeshiftLogin(options);
+
+  if (loginConfig) {
+    options.server = loginConfig.server;
+    options.token = loginConfig.token;
+    options.insecure = loginConfig.insecureSkipTlsVerify;
+  }
   // If there is a configLocation string, pass it in
   if (options.configLocation) {
     restClientConfig = options.configLocation;

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -10,6 +10,48 @@ test('export test', (t) => {
   t.end();
 });
 
+test('login goal', (t) => {
+  const cli = proxyquire('../bin/cli', {
+    '../lib/config/nodeshift-config': () => {
+      return Promise.resolve({});
+    },
+    '../lib/goals/resource': (config) => {
+      t.fail('should not be here for the login goal');
+    },
+    '../lib/goals/build': (config) => {
+      t.fail('should not be here for the login goal');
+    },
+    '../lib/goals/apply-resources': (config) => {
+      t.fail('should not be here for the login goal');
+    }
+  });
+
+  cli({ cmd: 'login' }).then(() => {
+    t.end();
+  });
+});
+
+test('logout goal', (t) => {
+  const cli = proxyquire('../bin/cli', {
+    '../lib/config/nodeshift-config': () => {
+      return Promise.resolve({});
+    },
+    '../lib/goals/resource': (config) => {
+      t.fail('should not be here for the logout goal');
+    },
+    '../lib/goals/build': (config) => {
+      t.fail('should not be here for the logout goal');
+    },
+    '../lib/goals/apply-resources': (config) => {
+      t.fail('should not be here for the logout goal');
+    }
+  });
+
+  cli({ cmd: 'logout' }).then(() => {
+    t.end();
+  });
+});
+
 test('default goal', (t) => {
   const cli = proxyquire('../bin/cli', {
     '../lib/config/nodeshift-config': () => {

--- a/test/config-tests/login-config-test.js
+++ b/test/config-tests/login-config-test.js
@@ -1,0 +1,336 @@
+'use strict';
+
+const test = require('tape');
+const proxyquire = require('proxyquire');
+
+test('login-config checkForNodeshiftLogin', (t) => {
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    fs: {
+      readFile: (location, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        return cb(null, JSON.stringify({ token: 'abcd', server: 'http' }));
+      }
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          t.equal(info, 'login.json file found');
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.checkForNodeshiftLogin({ projectLocation: 'here' }).then((loginJSON) => {
+    t.equal(loginJSON.token, 'abcd', 'returns the token');
+    t.equal(loginJSON.server, 'http', 'returns the server');
+    t.end();
+  }).catch(t.fail);
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});
+
+test('login-config checkForNodeshiftLogin - no login.json', (t) => {
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    fs: {
+      readFile: (location, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        const err = new Error('no file found');
+        err.code = 'ENOENT';
+        return cb(err);
+      }
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          t.equal(info, 'No login.json file found');
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.checkForNodeshiftLogin({ projectLocation: 'here' }).then((loginJSON) => {
+    t.pass();
+    t.end();
+  }).catch(t.fail);
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});
+
+test('login-config checkForNodeshiftLogin - some other error', (t) => {
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    fs: {
+      readFile: (location, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        const err = new Error('bad error');
+        err.code = 'SOMETHING';
+        return cb(err);
+      }
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          t.fail('should not be here');
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.checkForNodeshiftLogin({ projectLocation: 'here' }).then((loginJSON) => {
+    t.fail();
+    t.end();
+  }).catch(() => {
+    t.pass();
+    t.end();
+  });
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});
+
+test('login-config doNodeshiftLogout', (t) => {
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    fs: {
+      readFile: (location, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        return cb(null, JSON.stringify({ token: 'abcd', server: 'http' }));
+      }
+    },
+    '../utils/rmrf': (location) => {
+      t.equal(location, 'here/tmp/nodeshift/config', 'the location of the directory');
+      return Promise.resolve();
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          t.equal(info, 'Removing login.json to logout');
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.doNodeshiftLogout({ projectLocation: 'here' }).then((loginJSON) => {
+    t.pass();
+    t.end();
+  }).catch(t.fail);
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});
+
+test('login-config doNodeshiftLogout - no file to remove', (t) => {
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    fs: {
+      readFile: (location, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        const err = new Error('no file found');
+        err.code = 'ENOENT';
+        return cb(err);
+      }
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          t.equal(info, 'No login.json file found');
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.doNodeshiftLogout({ projectLocation: 'here' }).then((loginJSON) => {
+    t.pass();
+    t.end();
+  }).catch(t.fail);
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});
+
+test('login-config doNodeshiftLogout - some other error', (t) => {
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    fs: {
+      readFile: (location, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        const err = new Error('bad error');
+        err.code = 'SOMETHING';
+        return cb(err);
+      }
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          t.fail('should not be here');
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.doNodeshiftLogout({ projectLocation: 'here' }).then((loginJSON) => {
+    t.fail();
+    t.end();
+  }).catch(() => {
+    t.pass();
+    t.end();
+  });
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});
+
+test('login-config doNodeshiftLogin, already logged in, no force', (t) => {
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    fs: {
+      readFile: (location, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        return cb(null, JSON.stringify({ token: 'abcd', server: 'http' }));
+      }
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          t.equal(info, 'login.json file found');
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.doNodeshiftLogin({ projectLocation: 'here' }).then((loginJSON) => {
+    t.equal(loginJSON.token, 'abcd', 'returns the token');
+    t.equal(loginJSON.server, 'http', 'returns the server');
+    t.end();
+  }).catch(t.fail);
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});
+
+test('login-config doNodeshiftLogin, not logged in yet, passing a token', (t) => {
+  let counter = 0;
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    fs: {
+      writeFile: (location, data, options, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        t.equal(options.encoding, 'utf8', 'proper encoding');
+        return cb(null, '');
+      }
+    },
+    '../helpers': {
+      createDir: (location) => {
+        t.equal(location, 'here/tmp/nodeshift/config', 'the location of the directory');
+        return Promise.resolve();
+      }
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          if (counter === 0) {
+            t.equal(info, 'No login.json file found');
+          } else {
+            t.equal(info, 'logging in with nodeshift cli');
+          }
+          counter++;
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.doNodeshiftLogin({ projectLocation: 'here', token: 'abcd', server: 'http' }).then((loginJSON) => {
+    t.equal(loginJSON.token, 'abcd', 'returns the token');
+    t.equal(loginJSON.server, 'http', 'returns the server');
+    t.end();
+  }).catch(t.fail);
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});
+
+test('login-config doNodeshiftLogin, not logged in yet, passing a user/pass', (t) => {
+  let counter = 0;
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    'openshift-rest-client/lib/basic-auth-request': {
+      getTokenFromBasicAuth: (options) => {
+        t.equal(options.user, 'developer', 'has the username developer');
+        t.equal(options.password, 'developer', 'has the password developer');
+        t.equal(options.url, 'http', 'has the server http');
+        return Promise.resolve('abcd');
+      }
+    },
+    fs: {
+      writeFile: (location, data, options, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        t.equal(options.encoding, 'utf8', 'proper encoding');
+        return cb(null, '');
+      }
+    },
+    '../helpers': {
+      createDir: (location) => {
+        t.equal(location, 'here/tmp/nodeshift/config', 'the location of the directory');
+        return Promise.resolve();
+      }
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          if (counter === 0) {
+            t.equal(info, 'No login.json file found');
+          } else {
+            t.equal(info, 'logging in with nodeshift cli');
+          }
+          counter++;
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.doNodeshiftLogin({ projectLocation: 'here', username: 'developer', password: 'developer', server: 'http' }).then((loginJSON) => {
+    t.equal(loginJSON.token, 'abcd', 'returns the token');
+    t.equal(loginJSON.server, 'http', 'returns the server');
+    t.end();
+  }).catch(t.fail);
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});
+
+test('login-config doNodeshiftLogin, already logged in, passing a user/pass, forcing', (t) => {
+  const nodeshiftLogin = proxyquire('../../lib/config/login-config', {
+    'openshift-rest-client/lib/basic-auth-request': {
+      getTokenFromBasicAuth: (options) => {
+        t.equal(options.user, 'developer', 'has the username developer');
+        t.equal(options.password, 'developer', 'has the password developer');
+        t.equal(options.url, 'http', 'has the server http');
+        return Promise.resolve('abcd');
+      }
+    },
+    fs: {
+      writeFile: (location, data, options, cb) => {
+        t.equal(location, 'here/tmp/nodeshift/config/login.json', 'the location of the login.json file');
+        t.equal(options.encoding, 'utf8', 'proper encoding');
+        return cb(null, '');
+      }
+    },
+    '../helpers': {
+      createDir: (location) => {
+        t.equal(location, 'here/tmp/nodeshift/config', 'the location of the directory');
+        return Promise.resolve();
+      }
+    },
+    '../common-log': () => {
+      return {
+        info: (info) => {
+          t.equal(info, 'logging in with nodeshift cli');
+          return info;
+        }
+      };
+    }
+  });
+
+  const p = nodeshiftLogin.doNodeshiftLogin({ projectLocation: 'here', username: 'developer', password: 'developer', server: 'http', forceLogin: true }).then((loginJSON) => {
+    t.equal(loginJSON.token, 'abcd', 'returns the token');
+    t.equal(loginJSON.server, 'http', 'returns the server');
+    t.end();
+  }).catch(t.fail);
+
+  t.equal(p instanceof Promise, true, 'should return a Promise');
+});

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -8,6 +8,10 @@ test('api export', (t) => {
     './bin/cli': () => {}
   });
 
+  t.ok(api.login, 'should have a login function');
+  t.equals(typeof api.login, 'function', 'should be a function');
+  t.ok(api.logout, 'should have a logout function');
+  t.equals(typeof api.logout, 'function', 'should be a function');
   t.ok(api.deploy, 'should have a deploy function');
   t.equals(typeof api.deploy, 'function', 'should be a function');
   t.ok(api.resource, 'should have a resource function');
@@ -20,6 +24,28 @@ test('api export', (t) => {
   t.equals(typeof api.build, 'function', 'should be a function');
 
   t.end();
+});
+
+test('login api', (t) => {
+  const api = proxyquire('../', {
+    './bin/cli': (options) => {
+      t.equal(options.cmd, 'login', 'should be the login cmd');
+      t.end();
+    }
+  });
+
+  api.login();
+});
+
+test('logout api', (t) => {
+  const api = proxyquire('../', {
+    './bin/cli': (options) => {
+      t.equal(options.cmd, 'logout', 'should be the logout cmd');
+      t.end();
+    }
+  });
+
+  api.logout();
 });
 
 test('deploy api', (t) => {


### PR DESCRIPTION
This PR adds the `login` command.  It is meant to be run first with either a username/password or a valid token and the api server of the cluster

something like this: `nodeshift login --token=12345 --server=https.......`  then run `nodeshift deploy`.  While you can specify all those argument flags with the deploy command,  this cleans things up a bit

The new login command will write the authtoken and the api server to a login.json file that lives in `PROJECT_LOCATION/tmp/nodeshift/config/login.json`.  this tmp directory is also used in the build and deploy steps,  and should be gitignored.

CLI Usage - Login: 

```
$ nodeshift login --username=developer --password=password --server=https://api.server

or 

$ nodeshift login --token=12345 --server=https://api.server
```

CLI Usage - Logout

```
$ nodeshift logout
```

API usage using async/await would look something like this:

```
const nodeshift = require('nodeshift');

const options = {
  username: 'kubeadmin',
  password: '...',
  server: '...',
  insecure: true
};

(async () => {
  await nodeshift.login(options);
  await nodeshift.deploy();
  await nodeshift.logout();
})();
```
