### PR TITLE
add exposeHost option

### DIFF
--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -119,6 +119,10 @@ yargs
     type: 'boolean',
     default: false
   })
+  .options('exposeHost', {
+    describe: 'Alias/DNS that points to the service. Must be used with expose',
+    type: 'string'
+  })
   .options('namespace.displayName', {
     describe: 'flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files',
     type: 'string'
@@ -262,6 +266,7 @@ function createOptions (argv) {
   options.removeAll = argv.removeAll;
   options.namespace = argv.namespace;
   options.expose = argv.expose;
+  options.exposeHost = argv.exposeHost;
   options.configLocation = argv.configLocation;
 
   // Check for the --build.env array

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function logout (options = {}) {
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
-  @param {boolean} [options.exposeHost] - Alias/DNS that points to the service. Must be used with expose
+  @param {string} [options.exposeHost] - Alias/DNS that points to the service. Must be used with expose
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
@@ -93,7 +93,7 @@ function deploy (options = {}) {
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
-  @param {boolean} [options.exposeHost] - Alias/DNS that points to the service. Must be used with expose
+  @param {string} [options.exposeHost] - Alias/DNS that points to the service. Must be used with expose
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
@@ -129,7 +129,7 @@ function resource (options = {}) {
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
-  @param {boolean} [options.exposeHost] - Alias/DNS that points to the service. Must be used with expose
+  @param {string} [options.exposeHost] - Alias/DNS that points to the service. Must be used with expose
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function logout (options = {}) {
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
+  @param {boolean} [options.exposeHost] - Alias/DNS that points to the service. Must be used with expose
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
@@ -92,6 +93,7 @@ function deploy (options = {}) {
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
+  @param {boolean} [options.exposeHost] - Alias/DNS that points to the service. Must be used with expose
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
@@ -127,6 +129,7 @@ function resource (options = {}) {
   @param {string} [options.insecure] - flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
   @param {string} [options.forceLogin] - Force a login when using the apiServer login.  Only used with apiServer login.  default to false
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
+  @param {boolean} [options.exposeHost] - Alias/DNS that points to the service. Must be used with expose
   @param {object} [options.namespace] -
   @param {string} [options.namespace.displayName] - flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {boolean} [options.namespace.create] - flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name

--- a/lib/definitions/route-spec.js
+++ b/lib/definitions/route-spec.js
@@ -29,7 +29,7 @@ const baseRouteSpec = {
 };
 
 module.exports = (resource, config) => {
-  resource.spec = _.merge({}, baseRouteSpec, { port: { targetPort: config.port } }, resource.spec);
+  resource.spec = _.merge({}, baseRouteSpec, { port: { targetPort: config.port }, host: config.exposeHost }, resource.spec);
 
   resource.spec.to.name = resource.spec.to.name ? resource.spec.to.name : config.projectName;
   return resource;

--- a/test/definitions-tests/route-spec-test.js
+++ b/test/definitions-tests/route-spec-test.js
@@ -11,11 +11,13 @@ test('route spec test', (t) => {
 
   const config = {
     projectName: 'project name',
-    port: 8080
+    port: 8080,
+    exposeHost: 'project.name'
   };
 
   const rs = routeSpec(resource, config);
   t.equal(rs.spec.port.targetPort, 8080, 'targetPort should be 8080');
+  t.equal(rs.spec.host, 'project.name', 'host should be project.name');
   t.equal(rs.spec.to.kind, 'Service', 'should have a kind of Service');
   t.equal(rs.spec.to.name, config.projectName, `name should be config.name ${config.projectName}`);
   t.end();
@@ -29,17 +31,20 @@ test('route spec test', (t) => {
       },
       port: {
         targetPort: 3000
-      }
+      },
+      host: 'not.project.name'
     }
   };
 
   const config = {
     projectName: 'project name',
-    port: 8080
+    port: 8080,
+    exposeHost: 'project.name'
   };
 
   const rs = routeSpec(resource, config);
   t.equal(rs.spec.port.targetPort, 3000, 'targetPort should be 3000');
+  t.equal(rs.spec.host, 'not.project.name', `host should not be overridden and use ${resource.spec.host}`);
   t.equal(rs.spec.to.kind, 'Service', 'should have a kind of Service');
   t.equal(rs.spec.to.name, 'Not Project Name', `name should not be overridden and use ${resource.spec.to.name}`);
   t.end();


### PR DESCRIPTION
When using export, a Route is generated, but there was no way to define
the Alias/DNS that points to the service.