### PR TITLE
chore: update ingress to use the v1 api

### DIFF
--- a/lib/ingress.js
+++ b/lib/ingress.js
@@ -23,11 +23,11 @@ const { awaitRequest } = require('./helpers');
 
 module.exports = async function getIngress (config, ingressResource) {
   // First check to see if we already have a route created
-  let ingress = await awaitRequest(config.openshiftRestClient.apis.extensions.v1beta1.ns(config.namespace.name).ingresses(ingressResource.metadata.name).get());
+  let ingress = await awaitRequest(config.openshiftRestClient.apis['networking.k8s.io'].v1.ns(config.namespace.name).ingresses(ingressResource.metadata.name).get());
   if (ingress.code === 404) {
     // There isn't a ingress yet, so we need to create one
     log.info(`creating new ingress ${ingressResource.metadata.name}`);
-    ingress = await config.openshiftRestClient.apis.extensions.v1beta1.ns(config.namespace.name).ingresses.post({ body: ingressResource });
+    ingress = await config.openshiftRestClient.apis['networking.k8s.io'].v1.ns(config.namespace.name).ingresses.post({ body: ingressResource });
   } else {
     log.info(`using existing ingress ${ingress.body.metadata.name}`);
   }

--- a/test/ingress-test.js
+++ b/test/ingress-test.js
@@ -23,8 +23,8 @@ test('test ingress, already created', (t) => {
     projectVersion: '1.0.0',
     openshiftRestClient: {
       apis: {
-        extensions: {
-          v1beta1: {
+        'networking.k8s.io': {
+          v1: {
             ns: (namespace) => {
               return {
                 ingresses: (ingressName) => {
@@ -56,7 +56,7 @@ test('test ingress, already created', (t) => {
 test('test ingress, not created', (t) => {
   const ingress = require('../lib/ingress');
   const resource = {
-    apiVersion: 'extensions/v1beta1',
+    apiVersion: 'networking.k8s.io/v1',
     kind: 'Ingress',
     metadata: {
       name: 'nodejs-istio-circuit-breaker-gateway'
@@ -73,8 +73,8 @@ test('test ingress, not created', (t) => {
     projectVersion: '1.0.0',
     openshiftRestClient: {
       apis: {
-        extensions: {
-          v1beta1: {
+        'networking.k8s.io': {
+          v1: {
             ns: (namespace) => {
               if (call === 0) {
                 call++;


### PR DESCRIPTION
The current api `extensions.v1beta1` is being deprecated, this updates to the newest.

see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122