### PR TITLE
feat: allow pulling s2i image from image stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,11 +265,15 @@ flag to pass into the openshift rest client for logging in with a self signed ce
 Force a login when using the apiServer login.  Only used with apiServer login.  default to false
 
 #### imageTag
-Specify the tag of the docker image to use for the deployed application. defaults to latest.
-These version tags correspond to the RHSCL tags of the [ubi8/nodejs s2i images](https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/nodejs-14)
+Specify the tag of the docker image or image stream to use for the deployed application. defaults to latest.
+For docker images these version tags correspond to the RHSCL tags of the [ubi8/nodejs s2i images](https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/nodejs-14)
 
 #### dockerImage
 Specify the s2i builder image of Node.js to use for the deployed applications.  Defaults to [ubi8/nodejs s2i images](https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/nodejs-14)
+
+#### imageStream
+Specify the image stream from which to get the s2i image of Node.js to use for the deployed application. If not specified defaults to
+using a docker image instead.
 
 #### web-app
 Flag to automatically set the appropriate docker image for web app deployment. Defaults to false

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -83,8 +83,12 @@ yargs
     describe: 'the s2i image to use, defaults to registry.access.redhat.com/ubi8/nodejs-14',
     type: 'string'
   })
+  .options('imageStream', {
+    describe: 'the imageStream fromw which to pull the s2i image to use, if not specified defaults to using a docker image instead.',
+    type: 'string'
+  })
   .options('imageTag', {
-    describe: 'The tag of the docker image to use for the deployed application.',
+    describe: 'The tag of the docker image or image stream to use for the deployed application.',
     type: 'string',
     default: 'latest'
   })
@@ -263,6 +267,7 @@ function createOptions (argv) {
 
   options.projectLocation = argv.projectLocation;
   options.dockerImage = argv.dockerImage;
+  options.imageStream = argv.imageStream;
   options.imageTag = argv.imageTag;
   options.webApp = argv.webApp;
   options.resourceProfile = argv.resourceProfile;

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,6 +86,7 @@ export function deploy(options?: {
     };
     resourceProfile?: string;
     imageTag?: string;
+    ImageStram?: string;
     outputImageStream?: string;
     outputImageTag?: string;
     quiet?: boolean;
@@ -117,6 +118,8 @@ export function deploy(options?: {
   @param {string} [options.namespace.name] - flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
   @param {string} [options.resourceProfile] - Define a subdirectory below .nodeshift/ that indicates where Openshift resources are stored
   @param {string} [options.imageTag] - set the version to use for the ubi8/nodejs-14.  Versions are ubi8/nodejs-14 tags: https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14
+  @param {string} [options.dockerImage] - set the s2i Node.js docker image to use. The current default is ubi8/nodejs-14.
+  @param {string} [options.imageStream] - the image stream from which to get the Node.js s2i image to use. If not specified defaults to useing a Node.js docker image instead.
   @param {string} [options.outputImageStream] - the name of the ImageStream to output to.  Defaults to project name from package.json
   @param {string} [options.outputImageTag] - The tag of the ImageStream to output to. Defaults to latest
   @param {boolean} [options.quiet] - suppress INFO and TRACE lines from output logs

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -98,6 +98,7 @@ async function createOrUpdateBuildConfig (config) {
       forcePull: config.build.forcePull,
       incremental: config.build.incremental,
       dockerImage: config.dockerImage,
+      imageStream: config.imageStream,
       buildEnv: config.build.env,
       webApp: config.webApp,
       buildStrategy: config.build.strategy
@@ -117,6 +118,7 @@ async function createOrUpdateBuildConfig (config) {
       imageTag: config.imageTag,
       forcePull: config.build.forcePull,
       dockerImage: config.dockerImage,
+      imageStream: config.imageStream,
       buildEnv: config.build.env,
       webApp: config.webApp,
       buildStrategy: config.build.strategy

--- a/lib/definitions/build-strategy.js
+++ b/lib/definitions/build-strategy.js
@@ -48,13 +48,18 @@ module.exports = (options) => {
 
     // Just doing the source strategy
     logger.info(`Using s2i image ${options.dockerImage} with tag ${options.imageTag}`);
-    const dockerImageName = `${options.dockerImage}:${options.imageTag}`;
+    let imageKind = 'DockerImage';
+    let imageName = `${options.dockerImage}:${options.imageTag}`;
+    if (options.imageStream) {
+      imageKind = 'ImageStreamTag';
+      imageName = `${options.imageStream}:${options.imageTag}`;
+    }
 
     strategy.sourceStrategy = {
       env: env,
       from: {
-        kind: 'DockerImage',
-        name: dockerImageName
+        kind: imageKind,
+        name: imageName
       },
       incremental: options.incremental,
       forcePull: options.forcePull

--- a/test/definitions-tests/build-strategy-test.js
+++ b/test/definitions-tests/build-strategy-test.js
@@ -20,6 +20,12 @@ test('strategy with changed dockerTag', (t) => {
   t.end();
 });
 
+test('strategy with imageStream specified and updated tag', (t) => {
+  const result = buildStrategy({ imageTag: '1-20', buildStrategy: 'Source', imageStream: 'odbc-base' });
+  t.equal(result.sourceStrategy.from.name, 'odbc-base:1-20', 'image stream should be odbc-base:1-20');
+  t.end();
+});
+
 test('strategy with changed forcePull', (t) => {
   const result = buildStrategy({ forcePull: true, buildStrategy: 'Source' });
   t.equal(result.sourceStrategy.forcePull, true, 'forcePull on');
@@ -48,6 +54,15 @@ test('strategy with change dockerImage', (t) => {
   const result = buildStrategy({ dockerImage: 'lholmquist/centos7-s2i-nodejs', buildStrategy: 'Source', imageTag: 'latest' });
 
   t.equal(result.sourceStrategy.from.name, 'lholmquist/centos7-s2i-nodejs:latest', 'docker image should be latest lholmquist image');
+  t.equal(result.sourceStrategy.from.kind, 'DockerImage', 'kind should be DockerImage');
+  t.end();
+});
+
+test('strategy with imageStream specified', (t) => {
+  const result = buildStrategy({ imageStream: 'odbc-base', buildStrategy: 'Source', imageTag: 'latest' });
+
+  t.equal(result.sourceStrategy.from.name, 'odbc-base:latest', 'image name should be odbc-base:latest');
+  t.equal(result.sourceStrategy.from.kind, 'ImageStreamTag', 'kind should be ImageStreamTag');
   t.end();
 });
 


### PR DESCRIPTION
Make it possible to use an image stream to get
the base s2i image used. Useful if a user needs
to extend an s2i image when using OpenShift.

Signed-off-by: Michael Dawson <mdawson@devrus.com>