### PR TITLE
chore: drop Node.js 12

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Nodeshift is an opinionated command line application and programmable API that y
 
 ## Prerequisites
 
-* Node.js - version 12.x or greater
+* Node.js - version 14.x or greater
 
 ## Install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "typescript": "^4.6.3"
       },
       "engines": {
-        "node": "^16 || ^14 || ^12"
+        "node": "^16 || ^14"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "package-support.json"
   ],
   "engines": {
-    "node": "^16 || ^14 || ^12"
+    "node": "^16 || ^14"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This would require a semver major bump so may want to time landing/releasing appropriately.