### PR TITLE
fix: non-secure routes should redirect to the secure version.

### DIFF
--- a/lib/definitions/route-spec.js
+++ b/lib/definitions/route-spec.js
@@ -25,6 +25,9 @@ const _ = require('lodash');
 const baseRouteSpec = {
   to: {
     kind: 'Service'
+  },
+  tls: {
+    insecureEdgeTerminationPolicy: 'Redirect'
   }
 };
 

--- a/test/definitions-tests/route-spec-test.js
+++ b/test/definitions-tests/route-spec-test.js
@@ -20,6 +20,7 @@ test('route spec test', (t) => {
   t.equal(rs.spec.host, 'project.name', 'host should be project.name');
   t.equal(rs.spec.to.kind, 'Service', 'should have a kind of Service');
   t.equal(rs.spec.to.name, config.projectName, `name should be config.name ${config.projectName}`);
+  t.equal(rs.spec.tls.insecureEdgeTerminationPolicy, 'Redirect', 'tls.insecureEdgeTerminationPoliocy shoud be redirect');
   t.end();
 });
 


### PR DESCRIPTION
This was discovered using the Openshift Sandbox, where the application would only load on the insecure(http) route and not on the secure(https) route.  When creating a route through openshift, this part of the tls portion of the route spec gets created automatically.