### PR TITLE
feat!: make Deployment the default resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const options = {
 
 ### `.nodeshift` Directory
 
-The `.nodeshift` directory contains your resource fragments.  These are `.yml` files that describe your services, deployments, routes, etc.  By default, nodeshift will create a `Service` and `DeploymentConfig` in memory, if none are provided.  A `Route` resource fragment should be provided or use the `expose` flag if you want to expose your application to the outside world.
+The `.nodeshift` directory contains your resource fragments.  These are `.yml` files that describe your services, deployments, routes, etc.  By default, nodeshift will create a `Service` and `Deployment` in memory, if none are provided.  A `Route` resource fragment should be provided or use the `expose` flag if you want to expose your application to the outside world.
 
 For kubernetes based deployments,  a `Service` and `Deployment` will be created by default, if none are provided.  The `Service` is of a `LoadBalancer` type, so no `Ingress` is needed to expose the application.
 
@@ -108,7 +108,7 @@ The resource object's `Kind`, if not given, will be extracted from the filename.
 
 Enrichers will add things to the resource fragments, like missing metadata and labels.  If your project uses git, then annotations with the git branch and commit hash will be added to the metadata.
 
-Default Enrichers will also create a default Service and DeploymentConfig when none are provided.
+Default Enrichers will also create a default Service and Deployment when none are provided.
 
 The default port value is 8080, but that can be overridden with the `--deploy.port` flag.
 
@@ -195,7 +195,7 @@ nodeshift.deploy().then((response) => {
     console.log(err);
 })
 ````
-_please note: Currently, once a route, service, deployment config, build config, and imagestream config are created, those are re-used. The only thing that changes from deployment to deployment is the source code.  For application resources, you can update them by undeploying and then deploying again.  BuildConfigs and Imagestreams can be re-created using the --build.recreate flag_
+_please note: Currently, once a route, service, deployment, deployment config, build config, and imagestream config are created, those are re-used. The only thing that changes from deployment to deployment is the source code.  For application resources, you can update them by undeploying and then deploying again.  BuildConfigs and Imagestreams can be re-created using the --build.recreate flag_
 
 #### Using with Kubernetes
 
@@ -300,7 +300,7 @@ option to remove builds, buildConfigs and Imagestreams.  Defaults to false - **O
 Flag to update the default ports on the resource files. Defaults to 8080
 
 #### deploy.env
-Flag to pass deployment config environment variables as NAME=Value.  Can be used multiple times.  ex: `nodeshift --deploy.env NODE_ENV=development --deploy.env YARN_ENABLED=true`
+Flag to pass deployment/deploymeny config environment variables as NAME=Value.  Can be used multiple times.  ex: `nodeshift --deploy.env NODE_ENV=development --deploy.env YARN_ENABLED=true`
 
 #### build.recreate
 Flag to recreate a BuildConfig or Imagestream.  Defaults to false. Choices are "buildConfig", "imageStream", false, true.  If true, both are re-created
@@ -317,8 +317,8 @@ Flag to pass build config environment variables as NAME=Value.  Can be used mult
 #### build.strategy
 Flag to change the build strategy used.  Values can be Docker or Source.  Defaults to Source
 
-#### useDeployment
-Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+#### useDeploymentConfig
+Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
 
 #### knative
 EXPERIMENTAL. Flag to deploy an application as a Knative Serving Service.  Defaults to false
@@ -408,8 +408,8 @@ Shows the below help
             --metadata.out           determines what should be done with the response
                                     metadata from OpenShift
                     [string] [choices: "stdout", "ignore", "<filename>"] [default: "ignore"]
-            --useDeployment          flag to deploy the application using a Deployment
-                           instead of a DeploymentConfig
+            --useDeploymentConfig          flag to deploy the application using a DeploymentConfig
+                           instead of a Deployment
                                [boolean] [choices: true, false] [default: false]
             --knative                EXPERIMENTAL. flag to deploy an application
                            as a Knative Serving Service

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -181,8 +181,8 @@ yargs
     type: 'string',
     default: 'ignore'
   })
-  .options('useDeployment', {
-    describe: 'flag to deploy the application using a Deployment instead of a DeploymentConfig',
+  .options('useDeploymentConfig', {
+    describe: 'flag to deploy the application using a DeploymentConfig instead of a Deployment',
     choices: [true, false],
     type: 'boolean',
     default: false
@@ -229,7 +229,7 @@ function commandHandler (argv) {
 function createOptions (argv) {
   const options = {};
 
-  options.useDeployment = argv.useDeployment;
+  options.useDeploymentConfig = argv.useDeploymentConfig;
 
   // User wants to add red hat metering
   // This could be just use defaults based on the rh node image

--- a/docs/assets/anchor.js
+++ b/docs/assets/anchor.js
@@ -5,7 +5,7 @@
  */
 /* eslint-env amd, node */
 
-// https://github.com/umdjs/umd/blob/HEAD/templates/returnExports.js
+// https://github.com/umdjs/umd/blob/master/templates/returnExports.js
 (function (root, factory) {
   'use strict';
   if (typeof define === 'function' && define.amd) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset='utf-8'>
-  <title>nodeshift 7.2.0 | Documentation</title>
+  <title>nodeshift 11.3.0 | Documentation</title>
   <meta name='description' content='Plugin for running openshift deployments'>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' rel='stylesheet'>
@@ -15,7 +15,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>nodeshift</h3>
-          <div class='mb1'><code>7.2.0</code></div>
+          <div class='mb1'><code>11.3.0</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -32,6 +32,36 @@
                   href='#readme'
                   class="h5 bold black caps">
                   README
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#login'
+                  class="">
+                  login
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#logout'
+                  class="">
+                  logout
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#getnodeshiftconfig'
+                  class="">
+                  getNodeshiftConfig
                   
                 </a>
                 
@@ -104,13 +134,14 @@
   </h2>
 
   
-    <h1>Nodeshift <a href="https://circleci.com/gh/nodeshift/nodeshift"><img src="https://circleci.com/gh/nodeshift/nodeshift.svg?style=svg" alt="CircleCI"></a></h1>
-<p><a href="https://travis-ci.org/nodeshift/nodeshift"><img src="https://travis-ci.org/nodeshift/nodeshift.svg?branch=main" alt="Build Status"></a> <a href="https://coveralls.io/github/nodeshift/nodeshift?branch=main"><img src="https://coveralls.io/repos/github/nodeshift/nodeshift/badge.svg?branch=main" alt="Coverage Status"></a></p>
+    <h1>Nodeshift</h1>
+<p><img src="https://github.com/nodeshift/nodeshift/workflows/Node.js%20CI/badge.svg" alt="Node.js CI">
+<a href="https://coveralls.io/github/nodeshift/nodeshift?branch=main"><img src="https://coveralls.io/repos/github/nodeshift/nodeshift/badge.svg?branch=main" alt="Coverage Status"></a></p>
 <h2>What is it</h2>
-<p>Nodeshift is an opinionated command line application and programmable API that you can use to deploy Node.js projects to OpenShift.</p>
+<p>Nodeshift is an opinionated command line application and programmable API that you can use to deploy Node.js projects to OpenShift and Kubernetes(minikube).</p>
 <h2>Prerequisites</h2>
 <ul>
-<li>Node.js - version 10.x or greater</li>
+<li>Node.js - version 18.x or greater</li>
 </ul>
 <h2>Install</h2>
 <p>To install globally: <code>npm install -g nodeshift</code></p>
@@ -128,20 +159,52 @@ $ npm run nodeshift
 <h2>Core Concepts</h2>
 <h3>Commands &#x26; Goals</h3>
 <p>By default, if you run just <code>nodeshift</code>, it will run the <code>deploy</code> goal, which is a shortcut for running <code>resource</code>, <code>build</code> and <code>apply-resource</code>.</p>
+<p><strong>login</strong> - will login to the cluster</p>
+<p><strong>logout</strong> - will logout of the cluster</p>
 <p><strong>resource</strong> - will parse and create the application resources files on disk</p>
 <p><strong>apply-resource</strong> - does the resource goal and then deploys the resources to your running cluster</p>
 <p><strong>build</strong> - archives the code, creates a build config and imagestream and pushes the binary to the cluster</p>
 <p><strong>deploy</strong> -  a shortcut for running <code>resource</code>, <code>build</code> and <code>apply-resource</code></p>
 <p><strong>undeploy</strong> - removes resources that were deployed with the apply-resource command</p>
+<h3>Using Login and Logout</h3>
+<p>By default, the Nodeshift CLI will look for a kube config in <code>~/.kube/config</code>.  This is usually created when a user does an <code>oc login</code>,  but that requires the <code>oc</code> to be installed and the extra step of running the <code>oc login</code> command.  The Nodeshift CLI allows you to pass a username/password or a valid auth token along with the clusters API server address to authenticate requests without the need to run <code>oc login</code> first.</p>
+<p>While these parameters can be specified for each command, the <code>nodeshift login</code> command helps to simplify that.  You can now run <code>nodeshift login</code> with the parameters mentioned to first login, then run the usual <code>nodeshift deploy</code> without neededing to add the flags.</p>
+<p>CLI Usage - Login:</p>
+<pre><code>$ nodeshift login --username=developer --password=password --server=https://api.server
+
+or
+
+$ nodeshift login --token=12345 --server=https://api.server
+</code></pre>
+<p>CLI Usage - Logout</p>
+<pre><code>$ nodeshift logout
+</code></pre>
+<p>API usage using async/await would look something like this:</p>
+<pre><code>const nodeshift = require('nodeshift');
+
+const options = {
+  username: 'kubeadmin',
+  password: '...',
+  server: '...',
+  insecure: true
+};
+
+(async () => {
+  await nodeshift.login(options);
+  await nodeshift.deploy();
+  await nodeshift.logout();
+})();
+</code></pre>
 <h3><code>.nodeshift</code> Directory</h3>
-<p>The <code>.nodeshift</code> directory contains your resource fragments.  These are <code>.yml</code> files that describe your services, deployments, routes, etc.  By default, nodeshift will create a <code>Service</code> and <code>DeploymentConfig</code> in memory, if none are provided.  A <code>Route</code> resource fragment should be provided or use the <code>expose</code> flag if you want to expose your application to the outside world.</p>
+<p>The <code>.nodeshift</code> directory contains your resource fragments.  These are <code>.yml</code> files that describe your services, deployments, routes, etc.  By default, nodeshift will create a <code>Service</code> and <code>Deployment</code> in memory, if none are provided.  A <code>Route</code> resource fragment should be provided or use the <code>expose</code> flag if you want to expose your application to the outside world.</p>
+<p>For kubernetes based deployments,  a <code>Service</code> and <code>Deployment</code> will be created by default, if none are provided.  The <code>Service</code> is of a <code>LoadBalancer</code> type, so no <code>Ingress</code> is needed to expose the application.</p>
 <h3>Resource Fragments</h3>
 <p>OpenShift resource fragments are user provided YAML files which describe and enhance your deployed resources.  They are enriched with metadata, labels and more by nodeshift.</p>
 <p>Each resource gets its own file, which contains some skeleton of a resource description. Nodeshift will enrich it and then combine all the resources into a single openshift.yml and openshift.json(located in ./tmp/nodeshift/resource/).</p>
 <p>The resource object's <code>Kind</code>, if not given, will be extracted from the filename.</p>
 <h3>Enrichers</h3>
 <p>Enrichers will add things to the resource fragments, like missing metadata and labels.  If your project uses git, then annotations with the git branch and commit hash will be added to the metadata.</p>
-<p>Default Enrichers will also create a default Service and DeploymentConfig when none are provided.</p>
+<p>Default Enrichers will also create a default Service and Deployment when none are provided.</p>
 <p>The default port value is 8080, but that can be overridden with the <code>--deploy.port</code> flag.</p>
 <p>You can also override this value by providing a .nodeshift/deployment.yaml resource file</p>
 <h4>Resource Fragment Parameters</h4>
@@ -163,7 +226,6 @@ $ npm run nodeshift
 <p>To set that using nodeshift, use the <code>-d</code> option with a KEY=VALUE, like this:</p>
 <pre><code>nodeshift -d SSO_AUTH_SERVER_URL=https://sercure-url
 </code></pre>
-<!-- For more on writing openshift templates, [see here](https://docs.openshift.org/latest/dev_guide/templates.html#writing-templates) -->
 <h3>Project Archive</h3>
 <p>A user can specify exactly what files would like nodeshift to include to the archive it will generate by using the files property in package.json.</p>
 <p>If a user does not use the files property in the package.json to filter what files they would like to include, then nodeshift by default will include everything except the <strong>node_modules</strong>, <strong>.git</strong> and <strong>tmp</strong> directories.</p>
@@ -205,16 +267,23 @@ $ npm run nodeshift
 }
 </code></pre>
 <h4>Example Usage</h4>
-<pre class='hljs'><span class="hljs-keyword">const</span> nodeshift = <span class="hljs-built_in">require</span>(<span class="hljs-string">'nodeshift'</span>);
-
-<span class="hljs-comment">// Deploy an Application</span>
-nodeshift.deploy().then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> {
-    <span class="hljs-built_in">console</span>.log(response);
-    <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Application Deployed'</span>)
-}).catch(<span class="hljs-function">(<span class="hljs-params">err</span>) =&gt;</span> {
-    <span class="hljs-built_in">console</span>.log(err);
-})</pre>
-<p><em>please note: Currently, once a route, service, deployment config, build config, and imagestream config are created, those are re-used. The only thing that changes from deployment to deployment is the source code.  For application resources, you can update them by undeploying and then deploying again.  BuildConfigs and Imagestreams can be re-created using the --build.recreate flag</em></p>
+<p><em>please note: Currently, once a route, service, deployment, deployment config, build config, and imagestream config are created, those are re-used. The only thing that changes from deployment to deployment is the source code.  For application resources, you can update them by undeploying and then deploying again.  BuildConfigs and Imagestreams can be re-created using the --build.recreate flag</em></p>
+<h4>Using with Kubernetes</h4>
+<p>Nodeshift can deploy Node.js applications to a Kubernetes Cluster using the <code>--kube</code> flag.</p>
+<p>There are 2 options that can be passed.  <code>minikube</code> or <code>docker-desktop</code> . Passing just the <code>--kube</code> flag will default to minikube</p>
+<p>Nodeshift expects that your code has a Dockerfile in its root directory.  Then deploying to kubernetes is as easy as running:</p>
+<p><code>npx nodeshift --kube=minikube</code></p>
+<p>Note on Minikube: This connects to Minikubes docker server, create a new container and then deploy and expose that container with a <code>Deployment</code> and <code>Service</code></p>
+<p>To learn more about <a href="https://minikube.sigs.k8s.io/docs/start/">minikube</a>.</p>
+<p>To learn more about <a href="https://docs.docker.com/desktop/kubernetes/">docker-desktop</a>.</p>
+<h4>Openshift Rest Client Configuration</h4>
+<p>Nodeshift uses the <a href="https://github.com/nodeshift/openshift-rest-client">Openshift Rest Client</a> under the hood to make all REST calls to the cluster.  By default, the rest client will look at your <code>~/.kube/config</code> file to authenticate you.  This file will be created when you do an <code>oc login</code>.</p>
+<p>If you don't want to use <code>oc</code> to login first, you can pass in a username, password, and the server of the cluster to authenticate against.  If you are using a cluster with a self-signed certificate(like code ready containers), then you will need to add the <code>insecure</code> flag.</p>
+<p>Also note, that when accessing the cluster this way,  the namespace will default to <code>default</code>.  If you need to target another namespace,  use the <code>namespace.name</code> flag.  Just make sure the user you use has the appropriate permissions.</p>
+<p>An example of this might look something like this:</p>
+<p><code>npx nodeshift --username developer --password developer --server https://apiserver_for_cluster --insecure --namespace.name nodejs-examples</code></p>
+<p>You can also pass in a valid auth token using the <code>token</code> flag.  If both a token and username/password is specified,  the token will take the preference.</p>
+<p><code>npx nodeshift --token 123456789  --server https://apiserver_for_cluster --insecure --namespace.name nodejs-examples</code></p>
 <h2>Advanced Options</h2>
 <p>While nodeshift is very opinionated about deployment parameters, both the CLI and the API accept options that allow you to customize nodeshift's behavior.</p>
 <h4>version</h4>
@@ -223,15 +292,32 @@ nodeshift.deploy().then(<span class="hljs-function">(<span class="hljs-params">r
 <p>Changes the default location of where to look for your project. Defaults to your current working directory(CWD)</p>
 <h4>configLocation</h4>
 <p>This option is passed through to the <a href="https://www.npmjs.com/package/openshift-rest-client">Openshift Rest Client</a>.  Defaults to the <code>~/.kube/config</code></p>
+<h4>token</h4>
+<p>Auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password</p>
+<h4>username</h4>
+<p>username to pass into the openshift rest client for logging in with the API Server.</p>
+<h4>password</h4>
+<p>password to pass into the openshift rest client for logging in with the API Server.</p>
+<h4>server</h4>
+<p>server to pass into the openshift rest client for logging in with the API Server.</p>
+<h4>apiServer - Deprecated</h4>
+<p>Use server instead. apiServer to pass into the openshift rest client for logging in with the API Server.</p>
+<h4>insecure</h4>
+<p>flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false.</p>
+<h4>forceLogin</h4>
+<p>Force a login when using the apiServer login.  Only used with apiServer login.  default to false</p>
 <h4>imageTag</h4>
-<p>Specify the tag of the docker image to use for the deployed application. defaults to latest.
-These version tags correspond to the RHSCL tags of the <a href="https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/nodejs-10">ubi8/nodejs s2i images</a></p>
+<p>Specify the tag of the docker image or image stream to use for the deployed application. defaults to latest.
+For docker images these version tags correspond to the RHSCL tags of the <a href="https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/nodejs-14">ubi8/nodejs s2i images</a></p>
 <h4>dockerImage</h4>
-<p>Specify the s2i builder image of Node.js to use for the deployed applications.  Defaults to <a href="https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/nodejs-10">ubi8/nodejs s2i images</a></p>
+<p>Specify the s2i builder image of Node.js to use for the deployed applications.  Defaults to <a href="https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/nodejs-14">ubi8/nodejs s2i images</a></p>
+<h4>imageStream</h4>
+<p>Specify the image stream from which to get the s2i image of Node.js to use for the deployed application. If not specified defaults to
+using a docker image instead.</p>
 <h4>web-app</h4>
 <p>Flag to automatically set the appropriate docker image for web app deployment. Defaults to false</p>
 <h4>resourceProfile</h4>
-<p>Define a subdirectory below .nodeshift/ that indicates where Openshift resources are stored</p>
+<p>Define a subdirectory below .nodeshift/ that indicates where OpenShift resources are stored</p>
 <h4>outputImageStream</h4>
 <p>The name of the ImageStream to output to.  Defaults to project name from package.json</p>
 <h4>outputImageStreamTag</h4>
@@ -245,7 +331,7 @@ These version tags correspond to the RHSCL tags of the <a href="https://access.r
 <h4>deploy.port</h4>
 <p>Flag to update the default ports on the resource files. Defaults to 8080</p>
 <h4>deploy.env</h4>
-<p>Flag to pass deployment config environment variables as NAME=Value.  Can be used multiple times.  ex: <code>nodeshift --deploy.env NODE_ENV=development --deploy.env YARN_ENABLED=true</code></p>
+<p>Flag to pass deployment/deploymeny config environment variables as NAME=Value.  Can be used multiple times.  ex: <code>nodeshift --deploy.env NODE_ENV=development --deploy.env YARN_ENABLED=true</code></p>
 <h4>build.recreate</h4>
 <p>Flag to recreate a BuildConfig or Imagestream.  Defaults to false. Choices are "buildConfig", "imageStream", false, true.  If true, both are re-created</p>
 <h4>build.forcePull</h4>
@@ -256,11 +342,15 @@ These version tags correspond to the RHSCL tags of the <a href="https://access.r
 <p>Flag to pass build config environment variables as NAME=Value.  Can be used multiple times.  ex: <code>nodeshift --build.env NODE_ENV=development --build.env YARN_ENABLED=true</code></p>
 <h4>build.strategy</h4>
 <p>Flag to change the build strategy used.  Values can be Docker or Source.  Defaults to Source</p>
-<h4>useDeployment</h4>
-<p>Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false</p>
+<h4>useDeploymentConfig</h4>
+<p>Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false</p>
 <h4>knative</h4>
 <p>EXPERIMENTAL. Flag to deploy an application as a Knative Serving Service.  Defaults to false
 Since this feature is experimental,  it is subject to change without a Major version release until it is fully stable.</p>
+<h4>kube</h4>
+<p>Flag to deploy an application to a vanilla kubernetes cluster.  At the moment only Minikube is supported.</p>
+<h4>rh-metering</h4>
+<p>Flag to add some metering labels to a deployment.  To change the nodeVersion label, use <code>--rh-metering.nodeVersion</code> flag.  Intended for use with Red Hat product images.  For more information on metering for Red Hat images, see <a href="https://access.redhat.com/documentation/en-us/red_hat_build_of_node.js/14/html/release_notes_for_node.js_14/features-nodejs#node_js_metering_labels_for_openshift">here</a></p>
 <h4>help</h4>
 <p>Shows the below help</p>
 <pre><code>    Usage: nodeshift [--options]
@@ -271,11 +361,30 @@ Since this feature is experimental,  it is subject to change without a Major ver
         nodeshift resource        resource command
         nodeshift apply-resource  apply resource command
         nodeshift undeploy        undeploy resources
+        nodeshift login           login to the cluster
+        nodeshift logout          logout of the cluster
 
     Options:
         --version                Show version number                         [boolean]
         --projectLocation        change the default location of the project   [string]
+        --kube                   Flag to deploy an application to a vanilla kubernetes
+                       cluster.  At the moment only Minikube is supported.
+                                                                             [boolean]
         --configLocation         change the default location of the config    [string]
+        --token                  auth token to pass into the openshift rest client for
+                                 logging in.  Overrides the username/password [string]
+        --username               username to pass into the openshift rest client for
+                                 logging in                                   [string]
+        --password               password to pass into the openshift rest client for
+                                 logging in                                   [string]
+        --apiServer              Deprecated - use the "server" flag instead. server address to pass into the openshift rest client
+                                 for logging in                               [string]
+        --server                 server address to pass into the openshift rest client
+                                 for logging in                               [string]
+        --insecure               flag to pass into the openshift rest client for
+                                 logging in with a self signed cert.  Only used with
+                                 apiServer login                             [boolean]
+        --forceLogin             Force a login when using the apiServer login[boolean]
         --imageTag           The tag of the docker image to use for the deployed
                             application.                 [string] [default: "latest"]
         --web-app                flag to automatically set the appropriate docker image
@@ -319,8 +428,8 @@ Since this feature is experimental,  it is subject to change without a Major ver
         --metadata.out           determines what should be done with the response
                                 metadata from OpenShift
                 [string] [choices: "stdout", "ignore", "&#x3C;filename>"] [default: "ignore"]
-        --useDeployment          flag to deploy the application using a Deployment
-                       instead of a DeploymentConfig
+        --useDeploymentConfig          flag to deploy the application using a DeploymentConfig
+                       instead of a Deployment
                            [boolean] [choices: true, false] [default: false]
         --knative                EXPERIMENTAL. flag to deploy an application
                        as a Knative Serving Service
@@ -333,6 +442,641 @@ Since this feature is experimental,  it is subject to change without a Major ver
 
   
 </section></div>
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='login'>
+      login
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>The login function will login</p>
+
+    <div class='pre p1 fill-light mt0'>login(options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?
+            = <code>{}</code>)</code>
+	    Options object for the login function
+
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.projectLocation</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>the location(directory) of your projects package.json. Defaults to 
+<code>process.cwd</code>
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.token</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.username</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>username to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.password</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>password to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.apiServer</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.server</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>server to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.insecure</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.forceLogin</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Force a login when using the apiServer login.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>></code>:
+        Returns a JSON Object
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='logout'>
+      logout
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>The logout function will logout</p>
+
+    <div class='pre p1 fill-light mt0'>logout(options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?)</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?
+            = <code>{}</code>)</code>
+	    Options object for the logout function
+
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.projectLocation</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>the location(directory) of your projects package.json. Defaults to 
+<code>process.cwd</code>
+</span></td>
+</tr>
+
+
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='getnodeshiftconfig'>
+      getNodeshiftConfig
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>The getNodeshiftConfig function will return the config</p>
+
+    <div class='pre p1 fill-light mt0'>getNodeshiftConfig(options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?
+            = <code>{}</code>)</code>
+	    Options object for the getNodeshiftConfig function
+
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.projectLocation</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>the location(directory) of your projects package.json. Defaults to 
+<code>process.cwd</code>
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.token</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.username</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>username to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.password</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>password to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.apiServer</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.server</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>server to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.insecure</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.forceLogin</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Force a login when using the apiServer login.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.expose</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  </td>
+  <td class='break-word'><span>Set to true to create a default Route and expose the default service.  defaults to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.exposeHost</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Alias/DNS that points to the service. Must be used with expose
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.namespace</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
+  </td>
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
+</span></td>
+</tr>
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.namespace.displayName</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to specify the project namespace display name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
+</span></td>
+</tr>
+
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.namespace.create</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to create the namespace if it does not exist. Only applicable for the build and deploy command. Must be used with namespace.name
+</span></td>
+</tr>
+
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.namespace.name</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to specify the project namespace name to build/deploy into.  Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
+</span></td>
+</tr>
+
+
+  
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.resourceProfile</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Define a subdirectory below .nodeshift/ that indicates where Openshift resources are stored
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.imageTag</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>set the version to use for the ubi8/nodejs-14.  Versions are ubi8/nodejs-14 tags: 
+<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14</a>
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.outputImageStream</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>the name of the ImageStream to output to.  Defaults to project name from package.json
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.outputImageTag</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>The tag of the ImageStream to output to. Defaults to latest
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.quiet</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  </td>
+  <td class='break-word'><span>suppress INFO and TRACE lines from output logs
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.deploy</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
+  </td>
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
+</span></td>
+</tr>
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.deploy.port</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to update the default ports on the resource files. Defaults to 8080
+</span></td>
+</tr>
+
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.deploy.env</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>?</code>
+  </td>
+  <td class='break-word'><span>an array of objects to pass deployment config environment variables.  [{name: NAME_PROP, value: VALUE}]
+</span></td>
+</tr>
+
+
+  
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.build</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
+  </td>
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
+</span></td>
+</tr>
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.build.strategy</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to change the build strategy used.  Values can be Docker or Source.  Defaults to Source
+</span></td>
+</tr>
+
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.build.recreate</span> <code class='quiet'>string/boolean?</code>
+  </td>
+  <td class='break-word'><span>flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
+</span></td>
+</tr>
+
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.build.forcePull</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
+</span></td>
+</tr>
+
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.build.env</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>?</code>
+  </td>
+  <td class='break-word'><span>an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]
+</span></td>
+</tr>
+
+
+  
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.definedProperties</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a>?</code>
+  </td>
+  <td class='break-word'><span>Array of objects with the format { key: value }.  Used for template substitution
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.useDeploymentConfig</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  </td>
+  <td class='break-word'><span>Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.knative</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  </td>
+  <td class='break-word'><span>EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.kube</span> <code class='quiet'>string/boolean?</code>
+  </td>
+  <td class='break-word'><span>Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
+</span></td>
+</tr>
+
+
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>></code>:
+        Returns a JSON Object
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
           
         
           
@@ -398,6 +1142,69 @@ Since this feature is experimental,  it is subject to change without a Major ver
 
               
                 <tr>
+  <td class='break-word'><span class='code bold'>options.token</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.username</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>username to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.password</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>password to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.apiServer</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.server</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>server to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.insecure</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.forceLogin</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Force a login when using the apiServer login.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
   <td class='break-word'><span class='code bold'>options.expose</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
   <td class='break-word'><span>Set to true to create a default Route and expose the default service.  defaults to false
@@ -407,9 +1214,20 @@ Since this feature is experimental,  it is subject to change without a Major ver
 
               
                 <tr>
+  <td class='break-word'><span class='code bold'>options.exposeHost</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Alias/DNS that points to the service. Must be used with expose
+</span></td>
+</tr>
+
+
+              
+                <tr>
   <td class='break-word'><span class='code bold'>options.namespace</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -456,8 +1274,8 @@ Since this feature is experimental,  it is subject to change without a Major ver
                 <tr>
   <td class='break-word'><span class='code bold'>options.imageTag</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
   </td>
-  <td class='break-word'><span>set the version to use for the ubi8/nodejs-10.  Versions are ubi8/nodejs-10 tags: 
-<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10</a>
+  <td class='break-word'><span>set the version to use for the ubi8/nodejs-14.  Versions are ubi8/nodejs-14 tags: 
+<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14</a>
 </span></td>
 </tr>
 
@@ -493,7 +1311,9 @@ Since this feature is experimental,  it is subject to change without a Major ver
                 <tr>
   <td class='break-word'><span class='code bold'>options.deploy</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -510,8 +1330,7 @@ Since this feature is experimental,  it is subject to change without a Major ver
     <tr>
   <td class='break-word'><span class='code bold'>options.deploy.env</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>?</code>
   </td>
-  <td class='break-word'><span>an array of objects to pass deployment config environment variables.  
-[{name: NAME_PROP, value: VALUE}]
+  <td class='break-word'><span>an array of objects to pass deployment config environment variables.  [{name: NAME_PROP, value: VALUE}]
 </span></td>
 </tr>
 
@@ -523,7 +1342,9 @@ Since this feature is experimental,  it is subject to change without a Major ver
                 <tr>
   <td class='break-word'><span class='code bold'>options.build</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -558,8 +1379,7 @@ Since this feature is experimental,  it is subject to change without a Major ver
     <tr>
   <td class='break-word'><span class='code bold'>options.build.env</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>?</code>
   </td>
-  <td class='break-word'><span>an array of objects to pass build config environment variables.  
-[{name: NAME_PROP, value: VALUE}]
+  <td class='break-word'><span>an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]
 </span></td>
 </tr>
 
@@ -578,9 +1398,9 @@ Since this feature is experimental,  it is subject to change without a Major ver
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.useDeployment</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  <td class='break-word'><span class='code bold'>options.useDeploymentConfig</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
-  <td class='break-word'><span>Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+  <td class='break-word'><span>Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
 </span></td>
 </tr>
 
@@ -590,6 +1410,15 @@ Since this feature is experimental,  it is subject to change without a Major ver
   <td class='break-word'><span class='code bold'>options.knative</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
   <td class='break-word'><span>EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.kube</span> <code class='quiet'>string/boolean?</code>
+  </td>
+  <td class='break-word'><span>Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
 </span></td>
 </tr>
 
@@ -696,6 +1525,69 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
 
               
                 <tr>
+  <td class='break-word'><span class='code bold'>options.token</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.username</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>username to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.password</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>password to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.apiServer</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.server</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>server to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.insecure</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.forceLogin</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Force a login when using the apiServer login.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
   <td class='break-word'><span class='code bold'>options.expose</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
   <td class='break-word'><span>Set to true to create a default Route and expose the default service.  defaults to false
@@ -705,9 +1597,20 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
 
               
                 <tr>
+  <td class='break-word'><span class='code bold'>options.exposeHost</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Alias/DNS that points to the service. Must be used with expose
+</span></td>
+</tr>
+
+
+              
+                <tr>
   <td class='break-word'><span class='code bold'>options.namespace</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -745,8 +1648,8 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.imageTag</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
   </td>
-  <td class='break-word'><span>set the version to use for the ubi8/nodejs-10.  Versions are ubi8/nodejs-10 tags: 
-<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10</a>
+  <td class='break-word'><span>set the version to use for the ubi8/nodejs-14.  Versions are ubi8/nodejs-14 tags: 
+<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14</a>
 </span></td>
 </tr>
 
@@ -782,7 +1685,9 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.build</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -818,9 +1723,9 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.useDeployment</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  <td class='break-word'><span class='code bold'>options.useDeploymentConfig</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
-  <td class='break-word'><span>Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+  <td class='break-word'><span>Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
 </span></td>
 </tr>
 
@@ -830,6 +1735,15 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
   <td class='break-word'><span class='code bold'>options.knative</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
   <td class='break-word'><span>EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.kube</span> <code class='quiet'>string/boolean?</code>
+  </td>
+  <td class='break-word'><span>Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
 </span></td>
 </tr>
 
@@ -935,6 +1849,69 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
 
               
                 <tr>
+  <td class='break-word'><span class='code bold'>options.token</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.username</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>username to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.password</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>password to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.apiServer</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.server</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>server to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.insecure</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.forceLogin</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Force a login when using the apiServer login.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
   <td class='break-word'><span class='code bold'>options.expose</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
   <td class='break-word'><span>Set to true to create a default Route and expose the default service.  defaults to false
@@ -944,9 +1921,20 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
 
               
                 <tr>
+  <td class='break-word'><span class='code bold'>options.exposeHost</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Alias/DNS that points to the service. Must be used with expose
+</span></td>
+</tr>
+
+
+              
+                <tr>
   <td class='break-word'><span class='code bold'>options.namespace</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -993,8 +1981,8 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.imageTag</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
   </td>
-  <td class='break-word'><span>set the version to use for the ubi8/nodejs-10.  Versions are ubi8/nodejs-10 tags: 
-<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10</a>
+  <td class='break-word'><span>set the version to use for the ubi8/nodejs-14.  Versions are ubi8/nodejs-14 tags: 
+<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14</a>
 </span></td>
 </tr>
 
@@ -1030,7 +2018,9 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.deploy</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -1047,8 +2037,7 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
     <tr>
   <td class='break-word'><span class='code bold'>options.deploy.env</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>?</code>
   </td>
-  <td class='break-word'><span>an array of objects to pass deployment config environment variables.  
-[{name: NAME_PROP, value: VALUE}]
+  <td class='break-word'><span>an array of objects to pass deployment config environment variables.  [{name: NAME_PROP, value: VALUE}]
 </span></td>
 </tr>
 
@@ -1060,7 +2049,9 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.build</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -1096,9 +2087,9 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.useDeployment</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  <td class='break-word'><span class='code bold'>options.useDeploymentConfig</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
-  <td class='break-word'><span>Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+  <td class='break-word'><span>Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
 </span></td>
 </tr>
 
@@ -1108,6 +2099,15 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
   <td class='break-word'><span class='code bold'>options.knative</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
   <td class='break-word'><span>EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.kube</span> <code class='quiet'>string/boolean?</code>
+  </td>
+  <td class='break-word'><span>Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
 </span></td>
 </tr>
 
@@ -1213,9 +2213,74 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
 
               
                 <tr>
+  <td class='break-word'><span class='code bold'>options.token</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.username</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>username to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.password</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>password to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.apiServer</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.server</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>server to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.insecure</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.forceLogin</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Force a login when using the apiServer login.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
   <td class='break-word'><span class='code bold'>options.namespace</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -1262,8 +2327,8 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.imageTag</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
   </td>
-  <td class='break-word'><span>set the version to use for the ubi8/nodejs-10.  Versions are ubi8/nodejs-10 tags: 
-<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10</a>
+  <td class='break-word'><span>set the version to use for the ubi8/nodejs-14.  Versions are ubi8/nodejs-14 tags: 
+<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14</a>
 </span></td>
 </tr>
 
@@ -1308,7 +2373,9 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.deploy</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -1325,8 +2392,7 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
     <tr>
   <td class='break-word'><span class='code bold'>options.deploy.env</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>?</code>
   </td>
-  <td class='break-word'><span>an array of objects to pass deployment config environment variables.  
-[{name: NAME_PROP, value: VALUE}]
+  <td class='break-word'><span>an array of objects to pass deployment config environment variables.  [{name: NAME_PROP, value: VALUE}]
 </span></td>
 </tr>
 
@@ -1338,7 +2404,9 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.build</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -1374,9 +2442,9 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.useDeployment</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
+  <td class='break-word'><span class='code bold'>options.useDeploymentConfig</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
-  <td class='break-word'><span>Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+  <td class='break-word'><span>Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
 </span></td>
 </tr>
 
@@ -1386,6 +2454,15 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
   <td class='break-word'><span class='code bold'>options.knative</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?</code>
   </td>
   <td class='break-word'><span>EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.kube</span> <code class='quiet'>string/boolean?</code>
+  </td>
+  <td class='break-word'><span>Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
 </span></td>
 </tr>
 
@@ -1491,9 +2568,74 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
 
               
                 <tr>
+  <td class='break-word'><span class='code bold'>options.token</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>auth token to pass into the openshift rest client for logging in with the API Server.  Overrides the username/password
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.username</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>username to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.password</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>password to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.apiServer</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Deprecated - use server instead. apiServer to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.server</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>server to pass into the openshift rest client for logging in with the API Server
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.insecure</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>flag to pass into the openshift rest client for logging in with a self signed cert.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.forceLogin</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
+  </td>
+  <td class='break-word'><span>Force a login when using the apiServer login.  Only used with apiServer login.  default to false
+</span></td>
+</tr>
+
+
+              
+                <tr>
   <td class='break-word'><span class='code bold'>options.namespace</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -1531,8 +2673,8 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.imageTag</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
   </td>
-  <td class='break-word'><span>set the version to use for the ubi8/nodejs-10.  Versions are ubi8/nodejs-10 tags: 
-<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10</a>
+  <td class='break-word'><span>set the version to use for the ubi8/nodejs-14.  Versions are ubi8/nodejs-14 tags: 
+<a href="https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14">https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14</a>
 </span></td>
 </tr>
 
@@ -1568,7 +2710,9 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
                 <tr>
   <td class='break-word'><span class='code bold'>options.build</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>?</code>
   </td>
-  <td class='break-word'><span>-
+  <td class='break-word'><span><ul>
+<li></li>
+</ul>
 </span></td>
 </tr>
 
@@ -1603,8 +2747,7 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
     <tr>
   <td class='break-word'><span class='code bold'>options.build.env</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>?</code>
   </td>
-  <td class='break-word'><span>an array of objects to pass build config environment variables.  
-[{name: NAME_PROP, value: VALUE}]
+  <td class='break-word'><span>an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]
 </span></td>
 </tr>
 
@@ -1617,6 +2760,15 @@ An openshift.yaml and openshift.json will also be created in the ./tmp/nodeshift
   <td class='break-word'><span class='code bold'>options.definedProperties</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a>?</code>
   </td>
   <td class='break-word'><span>Array of objects with the format { key: value }.  Used for template substitution
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.kube</span> <code class='quiet'>string/boolean?</code>
+  </td>
+  <td class='break-word'><span>Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
 </span></td>
 </tr>
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function logout (options = {}) {
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {Array} [options.build.env] - an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
-  @param {boolean} [options.useDeployment] - Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+  @param {boolean} [options.useDeploymentConfig] - Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
   @param {boolean} [options.knative] - EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
   @param {string/boolean} [options.kube] - Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
   @returns {Promise<object>} - Returns a JSON Object
@@ -111,7 +111,7 @@ function getNodeshiftConfig (options = {}) {
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {Array} [options.build.env] - an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
-  @param {boolean} [options.useDeployment] - Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+  @param {boolean} [options.useDeploymentConfig] - Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
   @param {boolean} [options.knative] - EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
   @param {string/boolean} [options.kube] - Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
   @returns {Promise<object>} - Returns a JSON Object
@@ -148,7 +148,7 @@ function deploy (options = {}) {
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
-  @param {boolean} [options.useDeployment] - Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+  @param {boolean} [options.useDeploymentConfig] - Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
   @param {boolean} [options.knative] - EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
   @param {string/boolean} [options.kube] - Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
   @returns {Promise<object>} - Returns a JSON Object
@@ -188,7 +188,7 @@ function resource (options = {}) {
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
-  @param {boolean} [options.useDeployment] - Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+  @param {boolean} [options.useDeploymentConfig] - Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
   @param {boolean} [options.knative] - EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
   @param {string/boolean} [options.kube] - Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
   @returns {Promise<object>} - Returns a JSON Object
@@ -227,7 +227,7 @@ function applyResource (options = {}) {
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
-  @param {boolean} [options.useDeployment] - Flag to deploy the application using a Deployment instead of a DeploymentConfig. Defaults to false
+  @param {boolean} [options.useDeploymentConfig] - Flag to deploy the application using a DeploymentConfig instead of a Deployment. Defaults to false
   @param {boolean} [options.knative] - EXPERIMENTAL. flag to deploy an application as a Knative Serving Service.  Defaults to false
   @param {string/boolean} [options.kube] - Flag to deploy an application to a vanilla kubernetes cluster. Defaults to false. options are 'minikube' or 'docker-desktop'
   @returns {Promise<object>} - Returns a JSON Object

--- a/lib/enrich-resources.js
+++ b/lib/enrich-resources.js
@@ -21,7 +21,7 @@
 const loadEnrichers = require('./load-enrichers');
 const defaultEnrichers = require('./resource-enrichers/default-enrichers.json');
 const knativeEnrichers = require('./resource-enrichers/knative-enrichers.json');
-const deploymentEnrichers = require('./resource-enrichers/deployment-enrichers.json');
+const deploymentConfigEnrichers = require('./resource-enrichers/deployment-config-enrichers.json');
 const kubeEnrichers = require('./resource-enrichers/kubernetes-enrichers.json');
 
 // TODO: Add Knative Serving Enrichers to run instead?
@@ -34,7 +34,7 @@ module.exports = async (config, resourceList) => {
   // Loop through those and then enrich the items from the resourceList
   let enrichedList = resourceList;
   // the defaultEnrichers list will have the correct order
-  for (const enricher of (config.knative ? knativeEnrichers : config.useDeployment ? deploymentEnrichers : config.kube ? kubeEnrichers : defaultEnrichers)) {
+  for (const enricher of (config.knative ? knativeEnrichers : config.useDeploymentConfig ? deploymentConfigEnrichers : config.kube ? kubeEnrichers : defaultEnrichers)) {
     const fn = loadedEnrichers[enricher];
     if (typeof fn === 'function') {
       enrichedList = await fn(config, enrichedList);

--- a/lib/resource-enrichers/default-enrichers.json
+++ b/lib/resource-enrichers/default-enrichers.json
@@ -1,3 +1,3 @@
 [
-  "deployment-config", "deployment-env", "service", "route", "labels", "git-info", "health-check", "runtime-label", "meterting"
+  "deployment", "deployment-env", "service", "route", "labels", "git-info", "health-check", "runtime-label", "meterting"
 ]

--- a/lib/resource-enrichers/deployment-config-enrichers.json
+++ b/lib/resource-enrichers/deployment-config-enrichers.json
@@ -1,0 +1,3 @@
+[
+  "deployment-config", "deployment-env", "service", "route", "labels", "git-info", "health-check", "runtime-label", "meterting"
+]

--- a/lib/resource-enrichers/deployment-enrichers.json
+++ b/lib/resource-enrichers/deployment-enrichers.json
@@ -1,3 +1,0 @@
-[
-  "deployment", "service", "route", "labels", "git-info", "health-check", "runtime-label", "meterting"
-]

--- a/lib/resource-enrichers/deployment-env-enricher.js
+++ b/lib/resource-enrichers/deployment-env-enricher.js
@@ -22,7 +22,7 @@ const _ = require('lodash');
 
 async function addDeploymentEnvVars (config, resourceList) {
   return resourceList.map((resource) => {
-    if (resource.kind === 'DeploymentConfig') {
+    if (resource.kind === 'DeploymentConfig' || resource.kind === 'Deployment') {
       // Check for the env array in the spec.template.spec.containers array of the deployment config
       // If there is one, we need to see if it already has values and merge if necessarry
       const env = resource.spec.template.spec.containers[0].env;

--- a/test/enrich-resources-test.js
+++ b/test/enrich-resources-test.js
@@ -27,29 +27,32 @@ test('enrich-resource - enricher is not a function', (t) => {
   const enrichResource = proxyquire('../lib/enrich-resources', {
     './load-enrichers': () => {
       return {
-        'deployment-config': () => {
+        deployment: () => {
           i++;
-          t.pass('should get called');
+          t.pass('deployment should get called by default');
+        },
+        'deployment-config': () => {
+          t.fail('deployment-config should not get called by default');
         },
         route: () => {
           i++;
-          t.pass('should get called');
+          t.pass('route should get called by default');
         },
         service: () => {
           i++;
-          t.pass('should get called');
+          t.pass('service should get called by default');
         },
         labels: () => {
           i++;
-          t.pass('should get called');
+          t.pass('labels should get called by default');
         },
         'git-info': () => {
           i++;
-          t.pass('should get called');
+          t.pass('git-info should get called by default');
         },
         'health-check': () => {
           i++;
-          t.pass('should get called');
+          t.pass('health-check should get called by default');
         }
       };
     }
@@ -113,37 +116,36 @@ test('enrich-resource - deployment enrichers', (t) => {
       return {
         'deployment-config': () => {
           i++;
-          t.fail('should not get called');
+          t.pass('deployment-config should get called');
         },
         deployment: () => {
-          i++;
-          t.pass('should get called');
+          t.fail('deployment should not get called');
         },
         route: () => {
           i++;
-          t.pass('should get called');
+          t.pass('route should get called');
         },
         service: () => {
           i++;
-          t.pass('should get called');
+          t.pass('service should get called');
         },
         labels: () => {
           i++;
-          t.pass('should get called');
+          t.pass('labels should get called');
         },
         'git-info': () => {
           i++;
-          t.pass('should get called');
+          t.pass('git-info should get called');
         },
         'health-check': () => {
           i++;
-          t.pass('should get called');
+          t.pass('health-check should get called');
         }
       };
     }
   });
 
-  const p = enrichResource({ useDeployment: true }, []);
+  const p = enrichResource({ useDeploymentConfig: true }, []);
   t.ok(p instanceof Promise, 'should return a promise');
 
   p.then(() => {


### PR DESCRIPTION
This is a breaking change that removed the "--useDeployment" flag and replaces it with the "--useDeploymentConfig" flag making the Deployment resource the default

A DeploymentConfig has been deprecated since Openshift 4.14 and it is recommended to use a Deployment resource for new applications.

see https://docs.openshift.com/container-platform/4.18/applications/deployments/what-deployments-are.html