### PR TITLE
fix: add the correct buildname suffix

### DIFF
--- a/lib/config/nodeshift-config.js
+++ b/lib/config/nodeshift-config.js
@@ -178,12 +178,13 @@ async function setup (options = {}) {
   options.build.strategy = options.build.strategy || 'Source';
   // Make sure the first letter is upperCase
   options.build.strategy = _.upperFirst(options.build.strategy.toLowerCase());
-
   // We only support these 2 strategies, so convert to Source if it is an unknown start.
   if (options.build.strategy !== 'Docker' && options.build.strategy !== 'Source') {
     logger.warning(`An unknown build strategy, ${options.build.strategy}, was specified, using the Source strategy instead`);
     options.build.strategy = 'Source';
   }
+  // define the build name suffix
+  const buildNameSuffix = (options.build.strategy === 'Docker') ? '-docker' : '-s2i';
 
   options.dockerImage = options.dockerImage || DEFAULT_DOCKER_IMAGE;
   options.imageTag = options.imageTag || DEFAULT_DOCKER_TAG;
@@ -196,8 +197,8 @@ async function setup (options = {}) {
     port: options.deploy && options.deploy.port ? parseInt(options.deploy.port, 10) : 8080,
     projectName: projectName,
     projectVersion: projectPackage.version || '0.0.0',
-    // Since we are only doing s2i builds(atm), append the s2i bit to the end
-    buildName: `${projectName}-s2i`, // TODO(lholmquist):  this should probably change?
+    // Nodeshift supports both the s2i and docker build strategies, so we should append the correct suffix
+    buildName: `${projectName}${buildNameSuffix}`,
     // Load an instance of the Openshift Rest Client, https://www.npmjs.com/package/openshift-rest-client
     openshiftRestClient: restClient,
     dockerClient


### PR DESCRIPTION
When using the source strategy the buildName suffix is s2i and if using the Docker strategy the suffix should use docker